### PR TITLE
extend refresh time for the operator to reduce unneded calls to the API

### DIFF
--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ManagedKafkaRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ManagedKafkaRequestController.java
@@ -114,7 +114,7 @@ public class ManagedKafkaRequestController implements ResourceController<Managed
     return true;
   }
 
-  @Scheduled(every = "10s")
+  @Scheduled(every = "150s")
   void reloadUserKafkas() {
     LOG.info("Refreshing user kafkas");
 


### PR DESCRIPTION
This will call api 500 times a day which is acceptable. Comparing to the 10k a day with the current setting