### PR TITLE
chore: improve error for missing secret

### DIFF
--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/AccessTokenSecretTool.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/AccessTokenSecretTool.java
@@ -65,21 +65,14 @@ public class AccessTokenSecretTool {
   }
 
   private String getOfflineTokenFromSecret(String secretName, String namespace) {
-    var token =      k8sClient
-            .secrets()
-            .inNamespace(namespace)
-            .withName(secretName)
-            .get();
-    if(token !=null ) {
-      var offlineToken =
-              token
-                      .getData()
-                      .get(ACCESS_TOKEN_SECRET_KEY);
+    var token = k8sClient.secrets().inNamespace(namespace).withName(secretName).get();
+    if (token != null) {
+      var offlineToken = token.getData().get(ACCESS_TOKEN_SECRET_KEY);
       offlineToken = new String(Base64.getDecoder().decode(offlineToken));
 
       return offlineToken;
     }
-    throw new Error("Missing Offline Token Secret "+ secretName);
+    throw new Error("Missing Offline Token Secret " + secretName);
   }
 
   /**

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
@@ -49,13 +49,14 @@ public class KafkaApiClient {
     try {
       return createClient(accessToken).getKafkaById(kafkaId);
     } catch (ApiException e) {
+      String message = getStandarizedErrorMessage(e);
       throw new ConditionAwareException(
-          e.getMessage(),
+          message,
           e,
           KafkaCondition.Type.FoundKafkaById,
           KafkaCondition.Status.False,
           e.getClass().getName(),
-          e.getMessage());
+          message);
     }
   }
 
@@ -63,13 +64,14 @@ public class KafkaApiClient {
     try {
       return createClient(accessToken).listKafkas(null, null, null, null);
     } catch (ApiException e) {
+      String message = getStandarizedErrorMessage(e);
       throw new ConditionAwareException(
-          e.getMessage(),
+          message,
           e,
           KafkaCondition.Type.UserKafkasUpToDate,
           KafkaCondition.Status.False,
           e.getClass().getName(),
-          e.getMessage());
+          message);
     }
   }
 
@@ -81,13 +83,14 @@ public class KafkaApiClient {
       serviceAccountRequest.setName(spec.getServiceAccountName());
       return createClient(accessToken).createServiceAccount(serviceAccountRequest);
     } catch (ApiException e) {
+      String message = getStandarizedErrorMessage(e);
       throw new ConditionAwareException(
-          e.getMessage(),
+          message,
           e,
           KafkaCondition.Type.ServiceAccountCreated,
           KafkaCondition.Status.False,
           e.getClass().getName(),
-          e.getMessage());
+          message);
     }
   }
 
@@ -132,5 +135,27 @@ public class KafkaApiClient {
           e.getClass().getName(),
           e.getMessage());
     }
+  }
+
+  private String getStandarizedErrorMessage(ApiException e) {
+    if (e.getCode() == 504) {
+      return "Server timeout. Server is not responding";
+    }
+    if (e.getCode() == 500) {
+      return "Unknown server error.";
+    }
+    if (e.getCode() == 500) {
+      return "Unknown server error.";
+    }
+    if (e.getCode() == 400) {
+      return "Invalid request " + e.getMessage();
+    }
+    if (e.getCode() == 401) {
+      return "Auth Token is invalid.";
+    }
+    if (e.getCode() == 403) {
+      return "User not authorized to access the service";
+    }
+    return e.getMessage();
   }
 }


### PR DESCRIPTION
API oftentimes return HTML. We need to map status codes to provide controllable user experience - as we display those in the openshift UI.


CC @christiemolloy 