### PR TITLE
fix: Add NPE protections to the operator with proper validation messs…

### DIFF
--- a/source/rhoas/README.md
+++ b/source/rhoas/README.md
@@ -4,7 +4,6 @@ This operator creates and manages custom resources used by the RHOAS Kafka Servi
 # Prerequesites
  * Java 11+
  * Maven
- * A service-api token from cloud.redhat.com (Talk to Pete)
  * Access to a RHOAS services .
 
 # Building and Running

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/AbstractCloudServicesController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/AbstractCloudServicesController.java
@@ -29,8 +29,7 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
    * @param resource
    * @param context
    */
-  abstract void doCreateOrUpdateResource(T resource, Context<T> context)
-      throws ConditionAwareException;
+  abstract void doCreateOrUpdateResource(T resource, Context<T> context) throws Throwable;
 
   @Override
   /** This method is overriden by the proxies, but should not be overriden by you, the developer. */

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
@@ -3,6 +3,7 @@ package com.openshift.cloud.controllers;
 import com.openshift.cloud.beans.AccessTokenSecretTool;
 import com.openshift.cloud.beans.KafkaApiClient;
 import com.openshift.cloud.beans.KafkaK8sClients;
+import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.CloudServiceAccountRequest;
 import io.javaoperatorsdk.operator.api.*;
 import java.time.Instant;
@@ -22,8 +23,9 @@ public class CloudServiceAccountRequestController
   @Override
   void doCreateOrUpdateResource(
       CloudServiceAccountRequest resource, Context<CloudServiceAccountRequest> context)
-      throws ConditionAwareException {
+      throws ConditionAwareException, InvalidUserInputException {
 
+    validateResource(resource);
     var accessTokenSecretName = resource.getSpec().getAccessTokenSecretName();
     var namespace = resource.getMetadata().getNamespace();
 
@@ -41,5 +43,16 @@ public class CloudServiceAccountRequestController
     status.setServiceAccountSecretName(resource.getSpec().getServiceAccountSecretName());
 
     resource.setStatus(status);
+  }
+
+  void validateResource(CloudServiceAccountRequest resource) throws InvalidUserInputException {
+    ConditionUtil.assertNotNull(resource.getSpec(), "spec");
+    ConditionUtil.assertNotNull(
+        resource.getSpec().getAccessTokenSecretName(), "spec.accessTokenSecretName");
+    ConditionUtil.assertNotNull(
+        resource.getSpec().getServiceAccountName(), "spec.serviceAccountName");
+    ConditionUtil.assertNotNull(
+        resource.getSpec().getServiceAccountSecretName(), "spec.serviceAccountSecretName");
+    ConditionUtil.assertNotNull(resource.getMetadata().getNamespace(), "metadata.namespace");
   }
 }

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ConditionUtil.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ConditionUtil.java
@@ -4,6 +4,7 @@ import static com.openshift.cloud.v1alpha.models.KafkaCondition.Status.False;
 import static com.openshift.cloud.v1alpha.models.KafkaCondition.Status.True;
 
 import com.openshift.cloud.ApiException;
+import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.*;
 import com.openshift.cloud.v1alpha.models.KafkaCondition.Status;
 import java.time.ZoneOffset;
@@ -266,6 +267,14 @@ public class ConditionUtil {
         return "User not authorized to access the service";
       default:
         return String.format("Http Error Code %d", statusCode);
+    }
+  }
+
+  /** Assert value and throw exception if that is not used */
+  public static void assertNotNull(Object value, String key) throws InvalidUserInputException {
+    if (value == null) {
+      var message = String.format("%s should not be null", key);
+      throw new InvalidUserInputException(key, message);
     }
   }
 }

--- a/source/rhoas/src/main/java/com/openshift/cloud/utils/InvalidUserInputException.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/utils/InvalidUserInputException.java
@@ -1,0 +1,15 @@
+package com.openshift.cloud.utils;
+
+/** Exception raised when there is problem with validation of the CR */
+public class InvalidUserInputException extends Exception {
+
+  /**
+   * Constructs a new exception with the specified detail message. The cause is not initialized, and
+   * may subsequently be initialized by a call to {@link #initCause}.
+   *
+   * @param field field that was invalid/undefined/not meeting
+   */
+  public InvalidUserInputException(String field, String additionalMessage) {
+    super(String.format("Missing argument %s in CR, %s", field, additionalMessage));
+  }
+}


### PR DESCRIPTION
## Verification

Create objects with empty spec and see validation errros instead of NPE
For example:
```
apiVersion: rhoas.redhat.com/v1alpha1
kind: CloudServiceAccountRequest
metadata:
  name: service-account-1
spec:

```