### PR TITLE
Update build to include more operatorhub.io metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,12 @@ jobs:
     - name: Set QUAY Organization
       id: quay-organization
       run: echo "::set-output name=name::$( [ -z '${{ secrets.quay_organization }}' ] && echo 'rhoas' || echo '${{ secrets.quay_organization }}')"    
+    - name: Set Time
+      id: time
+      run: echo "::set-output name=time::$( date +%Y-%m-%d\ %H:%M:%S )"          
     - uses: actions/checkout@v2
     - name: Bump version
-      run: 'FORCE_VERSION=${GITHUB_REF##*/} olm/autoupdate.sh ${{ secrets.quay_robotaccount }} ${{ secrets.quay_robottoken }} ${{ steps.quay-organization.outputs.name }}'
+      run: 'FORCE_VERSION=${GITHUB_REF##*/} olm/autoupdate.sh ${{ secrets.quay_robotaccount }} ${{ secrets.quay_robottoken }} ${{ steps.quay-organization.outputs.name }} "${{steps.time.outputs.time}}"'
     - name: Load version number
       id: version-number
       run: echo "::set-output name=version::$(cat olm/version)"

--- a/olm/autoupdate.sh
+++ b/olm/autoupdate.sh
@@ -3,6 +3,7 @@
 ## First Parameter : Quay UserName
 ## Second Parameter : Quay Token
 ## Third Parameter : Quay Organization
+## Fourth Parameter : Time
 
 set -e
 
@@ -31,6 +32,7 @@ mkdir olm-catalog/rhoas-operator/$version
 cp -r olm-template/* olm-catalog/rhoas-operator/$version
 sed -i "s/{{version}}/$version/g" olm-catalog/rhoas-operator/$version/manifests/rhoas-operator.clusterserviceversion.yaml 
 sed -i "s/{{organization}}/$3/g" olm-catalog/rhoas-operator/$version/manifests/rhoas-operator.clusterserviceversion.yaml 
+sed -i "s/{{time}}/$4/g" olm-catalog/rhoas-operator/$version/manifests/rhoas-operator.clusterserviceversion.yaml 
 
 
 echo "Building bundle"

--- a/olm/olm-catalog/rhoas-operator/0.6.8/manifests/rhoas-operator.clusterserviceversion.yaml
+++ b/olm/olm-catalog/rhoas-operator/0.6.8/manifests/rhoas-operator.clusterserviceversion.yaml
@@ -3,13 +3,15 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: >-
-      [{"apiVersion":"","kind":"KafkaConnection","metadata":{"name":""},"spec":{}},{"apiVersion":"","kind":"CloudServiceAccountRequest","metadata":{"name":""},"spec":{}},{"apiVersion":"","kind":"CloudServicesRequest","metadata":{"name":""},"spec":{}}]
+      [{"apiVersion":"rhoas.redhat.com/v1alpha1","kind":"KafkaConnection","metadata":{"name":"example", "namespace":"example-namespace", "labels":{"app.kubernetes.io/component":"external-service", "app.kubernetes.io/managed-by":"rhoas"}},"spec":{"accessTokenSecretName":"rh-managed-services-api-accesstoken", "kafkaId":"exampleId","credentials":{"serviceAccountSecretName":"service-account-secret"}}},{"apiVersion":"rhoas.redhat.com/v1alpha1","kind":"CloudServiceAccountRequest","metadata":{"name":"example","namespace":"example-namespace"},"spec":{"serviceAccountName": "RhoasOperatorServiceAccount","serviceAccountDescription": "Operator created service account","serviceAccountSecretName": "service-account-credentials",  "accessTokenSecretName": "rh-managed-services-api-accesstoken"}},{"apiVersion":"rhoas.redhat.com/v1alpha1","kind":"CloudServicesRequest","metadata":{"name":"example","namespace":"example-namespace", "labels":{"app.kubernetes.io/component":"external-service", "app.kubernetes.io/managed-by":"rhoas"}},"spec":{"accessTokenSecretName": "rh-cloud-services-api-accesstoken"}}]
     categories: 'Developer Tools, OpenShift Optional, Integration & Delivery'
     certified: 'false'
     description: 'Red Hat OpenShift Application Services Operator'
     capabilities: Seamless Upgrades
     repository: 'https://github.com/redhat-developer/app-services-operator'
     olm.skipRange: ">=0.0.1 <0.6.8"    
+    containerImage: quay.io/rhoas/service-operator:0.6.8
+    createdAt: 2021-04-15 10:50:00
   name: rhoas-operator.0.6.8
 spec:
   apiservicedefinitions: {}
@@ -114,18 +116,22 @@ spec:
                     memory: 128Mi                
               serviceAccountName: rhoas-operator
   description:  >-
-    RHOAS Operator (Preview) creates instances of Red Hat OpenShift Application Services in your cluster.
+    **OpenShift Application Services Operator (RHOAS-Operator)** creates instances of Red Hat OpenShift Application Services in your cluster.  
+
 
     Red Hat OpenShift Application Services, when added to Red Hat OpenShift Dedicated, 
     provide a streamlined developer experience for building, deploying, 
-    and scaling cloud-native applications in open hybrid-cloud environments. 
+    and scaling cloud-native applications in open hybrid-cloud environments.   
     
-    Operator will enable developers to connect with their Application Services directly in their own cluster by using
-    [RHOAS cli](https://github.com/redhat-developer/app-services-cli) and OpenShift Console UI.
 
-    Operator currently enables developers to connect with their Red Hat OpenShift Streams for Apache Kafka (RHOSAK) instances.
+    RHOAS-Operator enables developers to connect with their Application Services directly in their own cluster by using
+    [RHOAS cli](https://github.com/redhat-developer/app-services-cli) and OpenShift Console UI.  
     
-  displayName: RHOAS
+
+    RHOAS-Operator requires developers to connect with their Red Hat OpenShift Streams for Apache Kafka (RHOSAK) instances.  
+    
+
+  displayName: RedHat OpenShift Application Services Operator (RHOAS-Operator)  (Preview)
   keywords:
   - cloud
   - rhoas

--- a/olm/olm-template/manifests/rhoas-operator.clusterserviceversion.yaml
+++ b/olm/olm-template/manifests/rhoas-operator.clusterserviceversion.yaml
@@ -3,12 +3,14 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: >-
-      [{"apiVersion":"","kind":"KafkaConnection","metadata":{"name":""},"spec":{}},{"apiVersion":"","kind":"CloudServiceAccountRequest","metadata":{"name":""},"spec":{}},{"apiVersion":"","kind":"CloudServicesRequest","metadata":{"name":""},"spec":{}}]
+      [{"apiVersion":"rhoas.redhat.com/v1alpha1","kind":"KafkaConnection","metadata":{"name":"example", "namespace":"example-namespace", "labels":{"app.kubernetes.io/component":"external-service", "app.kubernetes.io/managed-by":"rhoas"}},"spec":{"accessTokenSecretName":"rh-managed-services-api-accesstoken", "kafkaId":"exampleId","credentials":{"serviceAccountSecretName":"service-account-secret"}}},{"apiVersion":"rhoas.redhat.com/v1alpha1","kind":"CloudServiceAccountRequest","metadata":{"name":"example","namespace":"example-namespace"},"spec":{"serviceAccountName": "RhoasOperatorServiceAccount","serviceAccountDescription": "Operator created service account","serviceAccountSecretName": "service-account-credentials",  "accessTokenSecretName": "rh-managed-services-api-accesstoken"}},{"apiVersion":"rhoas.redhat.com/v1alpha1","kind":"CloudServicesRequest","metadata":{"name":"example","namespace":"example-namespace", "labels":{"app.kubernetes.io/component":"external-service", "app.kubernetes.io/managed-by":"rhoas"}},"spec":{"accessTokenSecretName": "rh-cloud-services-api-accesstoken"}}]
     categories: 'Developer Tools, OpenShift Optional, Integration & Delivery'
     certified: 'false'
     description: 'Red Hat OpenShift Application Services Operator'
     capabilities: Seamless Upgrades
     repository: 'https://github.com/redhat-developer/app-services-operator'
+    containerImage: quay.io/{{organization}}/service-operator:{{version}}
+    createdAt: {{time}}
     olm.skipRange: ">=0.0.1 <{{version}}"    
   name: rhoas-operator.{{version}}
 spec:
@@ -114,18 +116,22 @@ spec:
                     memory: 128Mi                
               serviceAccountName: rhoas-operator
   description:  >-
-    RHOAS Operator (Preview) creates instances of Red Hat OpenShift Application Services in your cluster.
+    **OpenShift Application Services Operator (RHOAS-Operator)** creates instances of Red Hat OpenShift Application Services in your cluster.  
+
 
     Red Hat OpenShift Application Services, when added to Red Hat OpenShift Dedicated, 
     provide a streamlined developer experience for building, deploying, 
-    and scaling cloud-native applications in open hybrid-cloud environments. 
+    and scaling cloud-native applications in open hybrid-cloud environments.   
     
-    Operator will enable developers to connect with their Application Services directly in their own cluster by using
-    [RHOAS cli](https://github.com/redhat-developer/app-services-cli) and OpenShift Console UI.
 
-    Operator currently enables developers to connect with their Red Hat OpenShift Streams for Apache Kafka (RHOSAK) instances.
+    RHOAS-Operator enables developers to connect with their Application Services directly in their own cluster by using
+    [RHOAS cli](https://github.com/redhat-developer/app-services-cli) and OpenShift Console UI.  
     
-  displayName: RHOAS
+
+    RHOAS-Operator requires developers to connect with their Red Hat OpenShift Streams for Apache Kafka (RHOSAK) instances.  
+    
+
+  displayName: RedHat OpenShift Application Services Operator (RHOAS-Operator)  (Preview)
   keywords:
   - cloud
   - rhoas


### PR DESCRIPTION
This PR updates the build to include more metadata for the operatorhub.io page as well as updates the 0.6.8 CSV with new operatorhub.io values as that version is being submitted.