### PR TITLE
build: updating quarkus sdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <java.version>11</java.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus.version>1.12.1.Final</quarkus.version>
+        <quarkus.version>1.13.1.Final</quarkus.version>
         <log4j2.version>2.13.3</log4j2.version>
 
     </properties>

--- a/source/model/pom.xml
+++ b/source/model/pom.xml
@@ -70,6 +70,19 @@
           <parameters>true</parameters>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jboss.jandex</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>1.0.8</version>
+        <executions>
+            <execution>
+                <id>make-index</id>
+                <goals>
+                    <goal>jandex</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
     </plugins>
   </build>
 </project>

--- a/source/rhoas/pom.xml
+++ b/source/rhoas/pom.xml
@@ -13,8 +13,8 @@
   <name>rhoas-operator</name>
   <description>rhoas-operator</description>
   <properties>
-    <fabric8.version>5.1.1</fabric8.version>
-    <quarkus.operator.sdk.version>1.8.0</quarkus.operator.sdk.version>
+    <fabric8.version>5.2.1</fabric8.version>
+    <quarkus.operator.sdk.version>1.8.3</quarkus.operator.sdk.version>
 
   </properties>
   

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/KafkaConnectionControllerTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/KafkaConnectionControllerTest.java
@@ -93,7 +93,8 @@ public class KafkaConnectionControllerTest {
     var metaData = status.getMetadata();
     assertEquals("PLAIN", metaData.get("saslMechanism"));
     assertEquals("SASL_SSL", metaData.get("securityProtocol"));
-    assertEquals("https://cloud.redhat.com/beta/application-services/streams/kafkas/1234567890",
+    assertEquals(
+        "https://cloud.redhat.com/beta/application-services/streams/kafkas/1234567890",
         metaData.get("cloudUI"));
     assertEquals("rhoas", metaData.get("provider"));
     assertEquals("kafka", metaData.get("type"));


### PR DESCRIPTION
This includes an update to the java operator sdk that fixes a problem where the k8s watches would silently die. Now if a watch dies it takes the operator with it. It should fix https://github.com/redhat-developer/app-services-operator/issues/182