### PR TITLE
fix: change extensively long operator name

### DIFF
--- a/olm/olm-template/manifests/rhoas-operator.clusterserviceversion.yaml
+++ b/olm/olm-template/manifests/rhoas-operator.clusterserviceversion.yaml
@@ -135,7 +135,7 @@ spec:
     RHOAS-Operator requires developers to connect with their Red Hat OpenShift Streams for Apache Kafka (RHOSAK) instances.  
     
 
-  displayName: RedHat OpenShift Application Services Operator (RHOAS-Operator)
+  displayName: OpenShift Application Services (RHOAS)
   keywords:
   - cloud
   - rhoas


### PR DESCRIPTION
Fix for #208 