### PR TITLE
build: fix formatter in JDK 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,5 +17,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Enforce Formatting
+      run: mvn formatter:validate
     - name: Build and run Unit tests
       run: mvn package --file pom.xml --no-transfer-progress

--- a/pom.xml
+++ b/pom.xml
@@ -55,17 +55,14 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.coveo</groupId>
-                <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.10</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>2.15.0</version>
+                <configuration>
+                    <configFile>${project.parent.basedir}/source/eclipse-formatter-config.xml</configFile>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+                </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/source/eclipse-formatter-config.xml
+++ b/source/eclipse-formatter-config.xml
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+<profile kind="CodeFormatterProfile" name="GoogleStyle" version="13">
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_prefer_two_fragments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_comment_inline_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_local_variable_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="1040"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression.count_dependent" value="16|4|80"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration.count_dependent" value="16|4|49"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_local_variable_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants.count_dependent" value="16|5|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_type_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_field_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment_new_line_at_start_of_html_paragraph" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comment_prefix" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_parameter_annotation" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter.count_dependent" value="1040|-1|1040"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.force_if_else_statement_brace" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="3"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_package_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="1585"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_new_anonymous_class" value="20"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_member_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_for_statement" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+</profile>
+</profiles>

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServiceAccountRequest.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServiceAccountRequest.java
@@ -14,9 +14,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 @Plural("cloudserviceaccountrequests")
 @Group("rhoas.redhat.com")
 @Version("v1alpha1")
-@Buildable(
-    builderPackage = "io.fabric8.kubernetes.api.builder",
-    editableEnabled = false,
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false,
     refs = @BuildableReference(CustomResource.class))
 public class CloudServiceAccountRequest
     extends CustomResource<CloudServiceAccountRequestSpec, CloudServiceAccountRequestStatus>
@@ -24,10 +22,8 @@ public class CloudServiceAccountRequest
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("cloudServiceAccountRequestSpec", getSpec())
-        .append("cloudServiceAccountRequestStatus", getStatus())
-        .toString();
+    return new ToStringBuilder(this).append("cloudServiceAccountRequestSpec", getSpec())
+        .append("cloudServiceAccountRequestStatus", getStatus()).toString();
   }
 
   @Override
@@ -44,9 +40,7 @@ public class CloudServiceAccountRequest
       return false;
     }
     CloudServiceAccountRequest rhs = ((CloudServiceAccountRequest) other);
-    return new EqualsBuilder()
-        .append(getSpec(), rhs.getSpec())
-        .append(getStatus(), rhs.getStatus())
+    return new EqualsBuilder().append(getSpec(), rhs.getSpec()).append(getStatus(), rhs.getStatus())
         .isEquals();
   }
 }

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServiceAccountRequestList.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServiceAccountRequestList.java
@@ -2,5 +2,5 @@ package com.openshift.cloud.v1alpha.models;
 
 import io.fabric8.kubernetes.client.CustomResourceList;
 
-public class CloudServiceAccountRequestList
-    extends CustomResourceList<CloudServiceAccountRequest> {}
+public class CloudServiceAccountRequestList extends CustomResourceList<CloudServiceAccountRequest> {
+}

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServiceAccountRequestSpec.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServiceAccountRequestSpec.java
@@ -28,9 +28,7 @@ public class CloudServiceAccountRequestSpec {
    * @param serviceAccountName
    * @param serviceAccountDescription
    */
-  public CloudServiceAccountRequestSpec(
-      String serviceAccountName,
-      String serviceAccountDescription,
+  public CloudServiceAccountRequestSpec(String serviceAccountName, String serviceAccountDescription,
       String serviceAccountSecretName) {
     super();
     this.serviceAccountName = serviceAccountName;

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServiceAccountRequestStatus.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServiceAccountRequestStatus.java
@@ -20,8 +20,8 @@ public class CloudServiceAccountRequestStatus {
    * @param message
    * @param updated
    */
-  public CloudServiceAccountRequestStatus(
-      String message, String updated, String serviceAccountSecretName) {
+  public CloudServiceAccountRequestStatus(String message, String updated,
+      String serviceAccountSecretName) {
     super();
     this.message = message;
     this.updated = updated;

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServicesRequest.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServicesRequest.java
@@ -14,20 +14,15 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 @Plural("cloudservicesrequests")
 @Group("rhoas.redhat.com")
 @Version("v1alpha1")
-@Buildable(
-    builderPackage = "io.fabric8.kubernetes.api.builder",
-    editableEnabled = false,
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false,
     refs = @BuildableReference(CustomResource.class))
-public class CloudServicesRequest
-    extends CustomResource<CloudServicesRequestSpec, CloudServicesRequestStatus>
-    implements Namespaced {
+public class CloudServicesRequest extends
+    CustomResource<CloudServicesRequestSpec, CloudServicesRequestStatus> implements Namespaced {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("cloudServicesRequestSpec", getSpec())
-        .append("cloudServicesRequestStatus", getStatus())
-        .toString();
+    return new ToStringBuilder(this).append("cloudServicesRequestSpec", getSpec())
+        .append("cloudServicesRequestStatus", getStatus()).toString();
   }
 
   @Override
@@ -44,9 +39,7 @@ public class CloudServicesRequest
       return false;
     }
     CloudServicesRequest rhs = ((CloudServicesRequest) other);
-    return new EqualsBuilder()
-        .append(getSpec(), rhs.getSpec())
-        .append(getStatus(), rhs.getStatus())
+    return new EqualsBuilder().append(getSpec(), rhs.getSpec()).append(getStatus(), rhs.getStatus())
         .isEquals();
   }
 }

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServicesRequestList.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServicesRequestList.java
@@ -2,4 +2,5 @@ package com.openshift.cloud.v1alpha.models;
 
 import io.fabric8.kubernetes.client.CustomResourceList;
 
-public class CloudServicesRequestList extends CustomResourceList<CloudServicesRequest> {}
+public class CloudServicesRequestList extends CustomResourceList<CloudServicesRequest> {
+}

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServicesRequestSpec.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/CloudServicesRequestSpec.java
@@ -29,8 +29,7 @@ public class CloudServicesRequestSpec {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("accessTokenSecretName", accessTokenSecretName)
+    return new ToStringBuilder(this).append("accessTokenSecretName", accessTokenSecretName)
         .toString();
   }
 

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/KafkaCondition.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/KafkaCondition.java
@@ -2,18 +2,11 @@ package com.openshift.cloud.v1alpha.models;
 
 public class KafkaCondition {
   public enum Type {
-    AcccesTokenSecretValid,
-    UserKafkasUpToDate,
-    ServiceAccountCreated,
-    ServiceAccountSecretCreated,
-    Finished,
-    FoundKafkaById;
+    AcccesTokenSecretValid, UserKafkasUpToDate, ServiceAccountCreated, ServiceAccountSecretCreated, Finished, FoundKafkaById;
   }
 
   public enum Status {
-    True,
-    False,
-    Unknown
+    True, False, Unknown
   }
 
   private Type type;

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/KafkaConnection.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/KafkaConnection.java
@@ -15,9 +15,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 @Plural("kafkaconnections")
 @Group("rhoas.redhat.com")
 @Version("v1alpha1")
-@Buildable(
-    builderPackage = "io.fabric8.kubernetes.api.builder",
-    editableEnabled = false,
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", editableEnabled = false,
     refs = @BuildableReference(CustomResource.class))
 public class KafkaConnection extends CustomResource<KafkaConnectionSpec, KafkaConnectionStatus>
     implements Namespaced {
@@ -27,10 +25,8 @@ public class KafkaConnection extends CustomResource<KafkaConnectionSpec, KafkaCo
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("kafkaConnectionSpec", getSpec())
-        .append("kafkaConnectionStatus", getStatus())
-        .toString();
+    return new ToStringBuilder(this).append("kafkaConnectionSpec", getSpec())
+        .append("kafkaConnectionStatus", getStatus()).toString();
   }
 
   @Override
@@ -47,9 +43,7 @@ public class KafkaConnection extends CustomResource<KafkaConnectionSpec, KafkaCo
       return false;
     }
     KafkaConnection rhs = ((KafkaConnection) other);
-    return new EqualsBuilder()
-        .append(getSpec(), rhs.getSpec())
-        .append(getStatus(), rhs.getStatus())
+    return new EqualsBuilder().append(getSpec(), rhs.getSpec()).append(getStatus(), rhs.getStatus())
         .isEquals();
   }
 

--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/KafkaConnectionStatus.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/KafkaConnectionStatus.java
@@ -23,8 +23,8 @@ public class KafkaConnectionStatus {
    * @param bootstrapServerHost
    * @param updated
    */
-  public KafkaConnectionStatus(
-      String message, String updated, String bootstrapServerHost, String serviceAccountSecretName) {
+  public KafkaConnectionStatus(String message, String updated, String bootstrapServerHost,
+      String serviceAccountSecretName) {
     super();
     this.message = message;
     this.updated = updated;

--- a/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
@@ -16,15 +16,20 @@ import org.jboss.logging.Logger;
 @QuarkusMain
 public class RHOASOperator implements QuarkusApplication {
 
-  @Inject Operator operator;
+  @Inject
+  Operator operator;
 
-  @Inject ConfigurationService configuration;
+  @Inject
+  ConfigurationService configuration;
 
-  @Inject KafkaConnectionController connectionController;
+  @Inject
+  KafkaConnectionController connectionController;
 
-  @Inject CloudServicesRequestController requestController;
+  @Inject
+  CloudServicesRequestController requestController;
 
-  @Inject CloudServiceAccountRequestController serviceAccountRequestController;
+  @Inject
+  CloudServiceAccountRequestController serviceAccountRequestController;
 
   @ConfigProperty(name = "rhoas.client.apiBasePath")
   String clientBasePath;

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaK8sClients.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaK8sClients.java
@@ -31,7 +31,8 @@ public final class KafkaK8sClients {
 
   private static final Logger LOG = Logger.getLogger(KafkaK8sClients.class.getName());
 
-  @Inject KubernetesClient client;
+  @Inject
+  KubernetesClient client;
 
   private CustomResourceDefinition akcCrd;
   private CustomResourceDefinition cscrCrd;
@@ -48,10 +49,9 @@ public final class KafkaK8sClients {
     this.csarCrd = initCloudServiceAccountRequestCRDAndClient(crds);
   }
 
-  public MixedOperation<KafkaConnection, KafkaConnectionList, Resource<KafkaConnection>>
-      kafkaConnection() {
-    KubernetesDeserializer.registerCustomKind(
-        getApiVersion(KafkaConnection.class), akcCrd.getKind(), KafkaConnection.class);
+  public MixedOperation<KafkaConnection, KafkaConnectionList, Resource<KafkaConnection>> kafkaConnection() {
+    KubernetesDeserializer.registerCustomKind(getApiVersion(KafkaConnection.class),
+        akcCrd.getKind(), KafkaConnection.class);
 
     var akcCrdContext = CustomResourceDefinitionContext.fromCrd(this.akcCrd);
 
@@ -59,34 +59,26 @@ public final class KafkaK8sClients {
     return client.customResources(akcCrdContext, KafkaConnection.class, KafkaConnectionList.class);
   }
 
-  public MixedOperation<
-          CloudServicesRequest, CloudServicesRequestList, Resource<CloudServicesRequest>>
-      cloudServicesRequest() {
-    KubernetesDeserializer.registerCustomKind(
-        getApiVersion(CloudServicesRequest.class), cscrCrd.getKind(), CloudServicesRequest.class);
+  public MixedOperation<CloudServicesRequest, CloudServicesRequestList, Resource<CloudServicesRequest>> cloudServicesRequest() {
+    KubernetesDeserializer.registerCustomKind(getApiVersion(CloudServicesRequest.class),
+        cscrCrd.getKind(), CloudServicesRequest.class);
 
     var akcCrdContext = CustomResourceDefinitionContext.fromCrd(this.cscrCrd);
 
     // lets create a client for the CRD
-    return client.customResources(
-        akcCrdContext, CloudServicesRequest.class, CloudServicesRequestList.class);
+    return client.customResources(akcCrdContext, CloudServicesRequest.class,
+        CloudServicesRequestList.class);
   }
 
-  public MixedOperation<
-          CloudServiceAccountRequest,
-          CloudServiceAccountRequestList,
-          Resource<CloudServiceAccountRequest>>
-      cloudServiceAccountRequest() {
-    KubernetesDeserializer.registerCustomKind(
-        getApiVersion(CloudServiceAccountRequest.class),
-        csarCrd.getKind(),
-        CloudServiceAccountRequest.class);
+  public MixedOperation<CloudServiceAccountRequest, CloudServiceAccountRequestList, Resource<CloudServiceAccountRequest>> cloudServiceAccountRequest() {
+    KubernetesDeserializer.registerCustomKind(getApiVersion(CloudServiceAccountRequest.class),
+        csarCrd.getKind(), CloudServiceAccountRequest.class);
 
     var akcCrdContext = CustomResourceDefinitionContext.fromCrd(this.csarCrd);
 
     // lets create a client for the CRD
-    return client.customResources(
-        akcCrdContext, CloudServiceAccountRequest.class, CloudServiceAccountRequestList.class);
+    return client.customResources(akcCrdContext, CloudServiceAccountRequest.class,
+        CloudServiceAccountRequestList.class);
   }
 
   private CustomResourceDefinition initCloudServiceAccountRequestCRDAndClient(
@@ -97,17 +89,13 @@ public final class KafkaK8sClients {
     var crdsItems = crds.customResourceDefinitions().list().getItems();
     var kafkaConnectionCRDName = CustomResource.getCRDName(CloudServiceAccountRequest.class);
 
-    var akcCrdOptional =
-        crdsItems.stream()
-            .filter(crd -> kafkaConnectionCRDName.equals(crd.getMetadata().getName()))
-            .findFirst();
+    var akcCrdOptional = crdsItems.stream()
+        .filter(crd -> kafkaConnectionCRDName.equals(crd.getMetadata().getName())).findFirst();
 
     if (akcCrdOptional.isEmpty()) {
       LOG.info("Creating CloudServiceAccountRequest CRD");
-      akcCrd =
-          CustomResourceDefinitionContext.v1beta1CRDFromCustomResourceType(
-                  CloudServiceAccountRequest.class)
-              .build();
+      akcCrd = CustomResourceDefinitionContext
+          .v1beta1CRDFromCustomResourceType(CloudServiceAccountRequest.class).build();
       client.apiextensions().v1beta1().customResourceDefinitions().create(akcCrd);
       LOG.info("CloudServiceAccountRequest CRD Created");
     } else {
@@ -126,16 +114,13 @@ public final class KafkaK8sClients {
     var crdsItems = crds.customResourceDefinitions().list().getItems();
     var kafkaConnectionCRDName = CustomResource.getCRDName(KafkaConnection.class);
 
-    var akcCrdOptional =
-        crdsItems.stream()
-            .filter(crd -> kafkaConnectionCRDName.equals(crd.getMetadata().getName()))
-            .findFirst();
+    var akcCrdOptional = crdsItems.stream()
+        .filter(crd -> kafkaConnectionCRDName.equals(crd.getMetadata().getName())).findFirst();
 
     if (akcCrdOptional.isEmpty()) {
       LOG.info("Creating KafkaConnection CRD");
-      akcCrd =
-          CustomResourceDefinitionContext.v1beta1CRDFromCustomResourceType(KafkaConnection.class)
-              .build();
+      akcCrd = CustomResourceDefinitionContext
+          .v1beta1CRDFromCustomResourceType(KafkaConnection.class).build();
       client.apiextensions().v1beta1().customResourceDefinitions().create(akcCrd);
       LOG.info("KafkaConnection CRD Created");
     } else {
@@ -154,17 +139,13 @@ public final class KafkaK8sClients {
     var crdsItems = crds.customResourceDefinitions().list().getItems();
     var cloudServicesRequestCRDName = CustomResource.getCRDName(CloudServicesRequest.class);
 
-    var akcCrdOptional =
-        crdsItems.stream()
-            .filter(crd -> cloudServicesRequestCRDName.equals(crd.getMetadata().getName()))
-            .findFirst();
+    var akcCrdOptional = crdsItems.stream()
+        .filter(crd -> cloudServicesRequestCRDName.equals(crd.getMetadata().getName())).findFirst();
 
     if (akcCrdOptional.isEmpty()) {
       LOG.info("Creating CloudServicesRequest CRD");
-      akcCrd =
-          CustomResourceDefinitionContext.v1beta1CRDFromCustomResourceType(
-                  CloudServicesRequest.class)
-              .build();
+      akcCrd = CustomResourceDefinitionContext
+          .v1beta1CRDFromCustomResourceType(CloudServicesRequest.class).build();
       client.apiextensions().v1beta1().customResourceDefinitions().create(akcCrd);
       LOG.info("CloudServicesRequest CRD Created");
     } else {
@@ -180,8 +161,8 @@ public final class KafkaK8sClients {
    * derived from the {@link Group} and {@link Version} annotations.
    *
    * @param clazz the HasMetadata whose {@code apiVersion} we want to compute
-   * @return the computed {@code apiVersion} or {@code null} if neither {@link Group} or {@link
-   *     Version} annotations are present
+   * @return the computed {@code apiVersion} or {@code null} if neither {@link Group} or
+   *         {@link Version} annotations are present
    * @throws IllegalArgumentException if only one of {@link Group} or {@link Version} is provided
    */
   static String getApiVersion(Class<? extends HasMetadata> clazz) {
@@ -191,12 +172,8 @@ public final class KafkaK8sClients {
       return group + "/" + version;
     }
     if (group != null || version != null) {
-      throw new IllegalArgumentException(
-          "You need to specify both @"
-              + Group.class.getSimpleName()
-              + " and @"
-              + Version.class.getSimpleName()
-              + " annotations if you specify either");
+      throw new IllegalArgumentException("You need to specify both @" + Group.class.getSimpleName()
+          + " and @" + Version.class.getSimpleName() + " annotations if you specify either");
     }
     return null;
   }
@@ -206,8 +183,8 @@ public final class KafkaK8sClients {
    * annotation.
    *
    * @param clazz the HasMetadata whose group we want to retrieve
-   * @return the associated group or {@code null} if the HasMetadata is not annotated with {@link
-   *     Group}
+   * @return the associated group or {@code null} if the HasMetadata is not annotated with
+   *         {@link Group}
    */
   static String getGroup(Class<? extends HasMetadata> clazz) {
     final Group group = clazz.getAnnotation(Group.class);
@@ -215,12 +192,12 @@ public final class KafkaK8sClients {
   }
 
   /**
-   * Retrieves the version associated with the specified HasMetadata as defined by the {@link
-   * Version} annotation.
+   * Retrieves the version associated with the specified HasMetadata as defined by the
+   * {@link Version} annotation.
    *
    * @param clazz the HasMetadata whose version we want to retrieve
-   * @return the associated version or {@code null} if the HasMetadata is not annotated with {@link
-   *     Version}
+   * @return the associated version or {@code null} if the HasMetadata is not annotated with
+   *         {@link Version}
    */
   static String getVersion(Class<? extends HasMetadata> clazz) {
     final Version version = clazz.getAnnotation(Version.class);

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/MockKafkaApiClient.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/MockKafkaApiClient.java
@@ -42,16 +42,15 @@ public class MockKafkaApiClient extends KafkaApiClient {
   }
 
   @Override
-  public void createSecretForServiceAccount(
-      CloudServiceAccountRequest resource, ServiceAccount serviceAccount)
-      throws ConditionAwareException {
+  public void createSecretForServiceAccount(CloudServiceAccountRequest resource,
+      ServiceAccount serviceAccount) throws ConditionAwareException {
     // NOOP
     // The secret is pseudo hard coded and will be returned as a hard coded value by the k8s mock
   }
 
   @Override
-  public ServiceAccount createServiceAccount(
-      CloudServiceAccountRequestSpec spec, String accessToken) throws ConditionAwareException {
+  public ServiceAccount createServiceAccount(CloudServiceAccountRequestSpec spec,
+      String accessToken) throws ConditionAwareException {
     ServiceAccount sa = new ServiceAccount();
     sa.setClientID("clientID");
     sa.setClientSecret("clientSecret");

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/AbstractCloudServicesController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/AbstractCloudServicesController.java
@@ -64,7 +64,7 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
    *
    * @param resource
    * @return true if resource has no status or conditions or if condition.finished.generation <
-   *     metadata.generation
+   *         metadata.generation
    */
   private boolean shouldProcess(T resource) {
 
@@ -79,9 +79,8 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
     }
 
     var finishedCondition = ConditionUtil.getCondition(conditions, Type.Finished);
-    if (finishedCondition.getLastTransitionGeneration() == null
-        || finishedCondition.getLastTransitionGeneration()
-            < resource.getMetadata().getGeneration()) {
+    if (finishedCondition.getLastTransitionGeneration() == null || finishedCondition
+        .getLastTransitionGeneration() < resource.getMetadata().getGeneration()) {
       return true;
     }
 
@@ -110,8 +109,8 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
     if (resource instanceof KafkaConnection) {
       ConditionUtil.setAllConditionsTrue(((KafkaConnection) resource).getStatus().getConditions());
     } else if (resource instanceof CloudServicesRequest) {
-      ConditionUtil.setAllConditionsTrue(
-          ((CloudServicesRequest) resource).getStatus().getConditions());
+      ConditionUtil
+          .setAllConditionsTrue(((CloudServicesRequest) resource).getStatus().getConditions());
     } else if (resource instanceof CloudServiceAccountRequest) {
       ConditionUtil.setAllConditionsTrue(
           ((CloudServiceAccountRequest) resource).getStatus().getConditions());
@@ -120,8 +119,8 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
 
   private void sealedSetErrorConditions(T resource, ConditionAwareException e) {
     if (resource instanceof KafkaConnection) {
-      ConditionUtil.setConditionFromException(
-          ((KafkaConnection) resource).getStatus().getConditions(), e);
+      ConditionUtil
+          .setConditionFromException(((KafkaConnection) resource).getStatus().getConditions(), e);
     } else if (resource instanceof CloudServicesRequest) {
       ConditionUtil.setConditionFromException(
           ((CloudServicesRequest) resource).getStatus().getConditions(), e);
@@ -155,14 +154,14 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
 
   private KafkaCondition getSealedErrorCondition(T resource, Type type) {
     if (resource instanceof KafkaConnection) {
-      return ConditionUtil.getCondition(
-          ((KafkaConnection) resource).getStatus().getConditions(), type);
+      return ConditionUtil.getCondition(((KafkaConnection) resource).getStatus().getConditions(),
+          type);
     } else if (resource instanceof CloudServicesRequest) {
-      return ConditionUtil.getCondition(
-          ((CloudServicesRequest) resource).getStatus().getConditions(), type);
+      return ConditionUtil
+          .getCondition(((CloudServicesRequest) resource).getStatus().getConditions(), type);
     } else if (resource instanceof CloudServiceAccountRequest) {
-      return ConditionUtil.getCondition(
-          ((CloudServiceAccountRequest) resource).getStatus().getConditions(), type);
+      return ConditionUtil
+          .getCondition(((CloudServiceAccountRequest) resource).getStatus().getConditions(), type);
     } else {
       throw new IllegalArgumentException(
           String.format("Resource of type %s is not supported", resource.getCRDName()));

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
@@ -14,15 +14,18 @@ import javax.inject.Inject;
 public class CloudServiceAccountRequestController
     extends AbstractCloudServicesController<CloudServiceAccountRequest> {
 
-  @Inject AccessTokenSecretTool accessTokenSecretTool;
+  @Inject
+  AccessTokenSecretTool accessTokenSecretTool;
 
-  @Inject KafkaK8sClients kafkaClientFactory;
+  @Inject
+  KafkaK8sClients kafkaClientFactory;
 
-  @Inject KafkaApiClient apiClient;
+  @Inject
+  KafkaApiClient apiClient;
 
   @Override
-  void doCreateOrUpdateResource(
-      CloudServiceAccountRequest resource, Context<CloudServiceAccountRequest> context)
+  void doCreateOrUpdateResource(CloudServiceAccountRequest resource,
+      Context<CloudServiceAccountRequest> context)
       throws ConditionAwareException, InvalidUserInputException {
 
     validateResource(resource);
@@ -47,12 +50,12 @@ public class CloudServiceAccountRequestController
 
   void validateResource(CloudServiceAccountRequest resource) throws InvalidUserInputException {
     ConditionUtil.assertNotNull(resource.getSpec(), "spec");
-    ConditionUtil.assertNotNull(
-        resource.getSpec().getAccessTokenSecretName(), "spec.accessTokenSecretName");
-    ConditionUtil.assertNotNull(
-        resource.getSpec().getServiceAccountName(), "spec.serviceAccountName");
-    ConditionUtil.assertNotNull(
-        resource.getSpec().getServiceAccountSecretName(), "spec.serviceAccountSecretName");
+    ConditionUtil.assertNotNull(resource.getSpec().getAccessTokenSecretName(),
+        "spec.accessTokenSecretName");
+    ConditionUtil.assertNotNull(resource.getSpec().getServiceAccountName(),
+        "spec.serviceAccountName");
+    ConditionUtil.assertNotNull(resource.getSpec().getServiceAccountSecretName(),
+        "spec.serviceAccountSecretName");
     ConditionUtil.assertNotNull(resource.getMetadata().getNamespace(), "metadata.namespace");
   }
 }

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServicesRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServicesRequestController.java
@@ -19,11 +19,14 @@ public class CloudServicesRequestController
   private static final Logger LOG =
       Logger.getLogger(CloudServicesRequestController.class.getName());
 
-  @Inject AccessTokenSecretTool accessTokenSecretTool;
+  @Inject
+  AccessTokenSecretTool accessTokenSecretTool;
 
-  @Inject KafkaK8sClients kafkaClientFactory;
+  @Inject
+  KafkaK8sClients kafkaClientFactory;
 
-  @Inject KafkaApiClient apiClient;
+  @Inject
+  KafkaApiClient apiClient;
 
   public CloudServicesRequestController() {}
 
@@ -34,8 +37,8 @@ public class CloudServicesRequestController
   }
 
   @Override
-  void doCreateOrUpdateResource(
-      CloudServicesRequest resource, Context<CloudServicesRequest> context)
+  void doCreateOrUpdateResource(CloudServicesRequest resource,
+      Context<CloudServicesRequest> context)
       throws ConditionAwareException, InvalidUserInputException {
     var accessTokenSecretName = resource.getSpec().getAccessTokenSecretName();
     var namespace = resource.getMetadata().getNamespace();
@@ -47,31 +50,24 @@ public class CloudServicesRequestController
 
     var userKafkas = new ArrayList<UserKafka>();
 
-    kafkaList.getItems().stream()
-        .forEach(
-            listItem -> {
-              var userKafka =
-                  new UserKafka()
-                      .setId(listItem.getId())
-                      .setName(listItem.getName())
-                      .setOwner(listItem.getOwner())
-                      .setBootstrapServerHost(listItem.getBootstrapServerHost())
-                      .setStatus(listItem.getStatus())
-                      .setCreatedAt(listItem.getCreatedAt().toInstant().toString())
-                      .setUpdatedAt(listItem.getUpdatedAt().toInstant().toString())
-                      .setProvider(listItem.getCloudProvider())
-                      .setRegion(listItem.getRegion());
+    kafkaList.getItems().stream().forEach(listItem -> {
+      var userKafka = new UserKafka().setId(listItem.getId()).setName(listItem.getName())
+          .setOwner(listItem.getOwner()).setBootstrapServerHost(listItem.getBootstrapServerHost())
+          .setStatus(listItem.getStatus())
+          .setCreatedAt(listItem.getCreatedAt().toInstant().toString())
+          .setUpdatedAt(listItem.getUpdatedAt().toInstant().toString())
+          .setProvider(listItem.getCloudProvider()).setRegion(listItem.getRegion());
 
-              userKafkas.add(userKafka);
-            });
+      userKafkas.add(userKafka);
+    });
 
     resource.getStatus().setUserKafkas(userKafkas);
   }
 
   void validateResource(CloudServicesRequest resource) throws InvalidUserInputException {
     ConditionUtil.assertNotNull(resource.getSpec(), "spec");
-    ConditionUtil.assertNotNull(
-        resource.getSpec().getAccessTokenSecretName(), "spec.accessTokenSecretName");
+    ConditionUtil.assertNotNull(resource.getSpec().getAccessTokenSecretName(),
+        "spec.accessTokenSecretName");
     ConditionUtil.assertNotNull(resource.getMetadata().getNamespace(), "metadata.namespace");
   }
 }

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ConditionAwareException.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ConditionAwareException.java
@@ -10,13 +10,8 @@ public class ConditionAwareException extends Exception {
   private final KafkaCondition.Status status;
   private String reason, conditionMessage;
 
-  public ConditionAwareException(
-      String exceptionMessage,
-      Throwable cause,
-      KafkaCondition.Type type,
-      KafkaCondition.Status status,
-      String reason,
-      String conditionMessage) {
+  public ConditionAwareException(String exceptionMessage, Throwable cause, KafkaCondition.Type type,
+      KafkaCondition.Status status, String reason, String conditionMessage) {
     super(exceptionMessage, cause);
     this.type = type;
     this.status = status;

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ConditionUtil.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ConditionUtil.java
@@ -20,17 +20,20 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
- * This class contains utility methods to set conditions on {@link CloudServicesRequest}, {@link
- * KafkaConnection}, and {@link CloudServiceAccountRequest}.
+ * This class contains utility methods to set conditions on {@link CloudServicesRequest},
+ * {@link KafkaConnection}, and {@link CloudServiceAccountRequest}.
  *
- * <p>When you receive one of these objects in an operator, you should call initializeConditions
- * with that object. Operations on that object inside of a controller should be wrapped in a try
- * catch block.
+ * <p>
+ * When you receive one of these objects in an operator, you should call initializeConditions with
+ * that object. Operations on that object inside of a controller should be wrapped in a try catch
+ * block.
  *
- * <p>The catch block should catch on a {@link ConditionAwareException} and call
+ * <p>
+ * The catch block should catch on a {@link ConditionAwareException} and call
  * setConditionFromException on that object.
  *
- * <p>If your controller does not encounter {@link ConditionAwareException}, please call
+ * <p>
+ * If your controller does not encounter {@link ConditionAwareException}, please call
  * setAllConditionsTrue on the object before you write it back to k8s.
  */
 public class ConditionUtil {
@@ -40,12 +43,9 @@ public class ConditionUtil {
   public static void initializeConditions(CloudServicesRequest resource) {
     var status = resource.getStatus();
     if (status == null) {
-      resource.setStatus(
-          new CloudServicesRequestStatusBuilder()
-              .withLastUpdate(isoNow())
-              .withUserKafkas(new ArrayList<>())
-              .withConditions(cloudServicesRequestDefaultConditions(1))
-              .build());
+      resource.setStatus(new CloudServicesRequestStatusBuilder().withLastUpdate(isoNow())
+          .withUserKafkas(new ArrayList<>())
+          .withConditions(cloudServicesRequestDefaultConditions(1)).build());
     } else {
       status.setConditions(
           cloudServicesRequestDefaultConditions(resource.getMetadata().getGeneration()));
@@ -54,26 +54,14 @@ public class ConditionUtil {
 
   private static List<KafkaCondition> cloudServicesRequestDefaultConditions(long generation) {
     return List.of(
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setType(KafkaCondition.Type.AcccesTokenSecretValid)
-            .setReason("")
-            .setMessage("")
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setType(KafkaCondition.Type.AcccesTokenSecretValid).setReason("").setMessage("")
             .setStatus(KafkaCondition.Status.Unknown),
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setReason("")
-            .setMessage("")
-            .setType(KafkaCondition.Type.Finished)
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setReason("").setMessage("").setType(KafkaCondition.Type.Finished)
             .setStatus(KafkaCondition.Status.Unknown),
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setReason("")
-            .setMessage("")
-            .setType(KafkaCondition.Type.UserKafkasUpToDate)
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setReason("").setMessage("").setType(KafkaCondition.Type.UserKafkasUpToDate)
             .setStatus(KafkaCondition.Status.Unknown));
   }
 
@@ -83,8 +71,8 @@ public class ConditionUtil {
    * @param conditions a list of conditions that contains the condition in e as well as False.
    * @param e the exception
    */
-  public static void setConditionFromException(
-      List<KafkaCondition> conditions, ConditionAwareException e) {
+  public static void setConditionFromException(List<KafkaCondition> conditions,
+      ConditionAwareException e) {
     var condition = getCondition(conditions, e.getType());
     condition.setLastTransitionTime(isoNow());
     condition.setMessage(e.getConditionMessage());
@@ -104,18 +92,14 @@ public class ConditionUtil {
     }
   }
 
-  public static KafkaCondition getCondition(
-      List<KafkaCondition> resource, KafkaCondition.Type type) {
-    return resource.stream()
-        .filter(condition -> condition.getType() == (type))
-        .findFirst()
-        .orElseThrow(
-            () -> {
-              return new RuntimeException(
-                  resource.stream().map(a -> a.getType().name()).collect(Collectors.joining(", "))
-                      + " does not equal"
-                      + type);
-            });
+  public static KafkaCondition getCondition(List<KafkaCondition> resource,
+      KafkaCondition.Type type) {
+    return resource.stream().filter(condition -> condition.getType() == (type)).findFirst()
+        .orElseThrow(() -> {
+          return new RuntimeException(
+              resource.stream().map(a -> a.getType().name()).collect(Collectors.joining(", "))
+                  + " does not equal" + type);
+        });
   }
 
   private static String isoNow() {
@@ -125,10 +109,8 @@ public class ConditionUtil {
   public static void initializeConditions(CloudServiceAccountRequest resource) {
     var status = resource.getStatus();
     if (status == null) {
-      resource.setStatus(
-          new CloudServiceAccountRequestStatusBuilder()
-              .withConditions(kafkaServiceAccountRequestDefaultConditions(1))
-              .build());
+      resource.setStatus(new CloudServiceAccountRequestStatusBuilder()
+          .withConditions(kafkaServiceAccountRequestDefaultConditions(1)).build());
     } else {
       status.setConditions(
           kafkaServiceAccountRequestDefaultConditions(resource.getMetadata().getGeneration()));
@@ -137,81 +119,50 @@ public class ConditionUtil {
 
   private static List<KafkaCondition> kafkaServiceAccountRequestDefaultConditions(long generation) {
     return List.of(
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setType(KafkaCondition.Type.AcccesTokenSecretValid)
-            .setReason("")
-            .setMessage("")
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setType(KafkaCondition.Type.AcccesTokenSecretValid).setReason("").setMessage("")
             .setStatus(KafkaCondition.Status.Unknown),
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setReason("")
-            .setMessage("")
-            .setType(KafkaCondition.Type.ServiceAccountCreated)
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setReason("").setMessage("").setType(KafkaCondition.Type.ServiceAccountCreated)
             .setStatus(KafkaCondition.Status.Unknown),
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setReason("")
-            .setMessage("")
-            .setType(KafkaCondition.Type.ServiceAccountSecretCreated)
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setReason("").setMessage("").setType(KafkaCondition.Type.ServiceAccountSecretCreated)
             .setStatus(KafkaCondition.Status.Unknown),
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setReason("")
-            .setMessage("")
-            .setType(KafkaCondition.Type.Finished)
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setReason("").setMessage("").setType(KafkaCondition.Type.Finished)
             .setStatus(Status.Unknown));
   }
 
   public static void setAllConditionsTrue(List<KafkaCondition> conditions) {
-    conditions.forEach(
-        condition -> {
-          condition.setLastTransitionTime(isoNow());
-          condition.setMessage("");
-          condition.setStatus(True);
-          condition.setReason("");
-        });
+    conditions.forEach(condition -> {
+      condition.setLastTransitionTime(isoNow());
+      condition.setMessage("");
+      condition.setStatus(True);
+      condition.setReason("");
+    });
   }
 
   public static void initializeConditions(KafkaConnection resource) {
     var status = resource.getStatus();
     if (status == null) {
-      resource.setStatus(
-          new KafkaConnectionStatusBuilder()
-              .withConditions(kafkaConnectionDefaultConditions(1))
-              .build());
+      resource.setStatus(new KafkaConnectionStatusBuilder()
+          .withConditions(kafkaConnectionDefaultConditions(1)).build());
     } else {
-      status.setConditions(
-          kafkaConnectionDefaultConditions(resource.getMetadata().getGeneration()));
+      status
+          .setConditions(kafkaConnectionDefaultConditions(resource.getMetadata().getGeneration()));
     }
   }
 
   private static List<KafkaCondition> kafkaConnectionDefaultConditions(long generation) {
     return List.of(
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setType(KafkaCondition.Type.AcccesTokenSecretValid)
-            .setReason("")
-            .setMessage("")
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setType(KafkaCondition.Type.AcccesTokenSecretValid).setReason("").setMessage("")
             .setStatus(KafkaCondition.Status.Unknown),
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setType(KafkaCondition.Type.FoundKafkaById)
-            .setLastTransitionGeneration(generation)
-            .setReason("")
-            .setMessage("")
-            .setStatus(KafkaCondition.Status.Unknown),
-        new KafkaCondition()
-            .setLastTransitionTime(isoNow())
-            .setLastTransitionGeneration(generation)
-            .setReason("")
-            .setMessage("")
-            .setType(KafkaCondition.Type.Finished)
+        new KafkaCondition().setLastTransitionTime(isoNow())
+            .setType(KafkaCondition.Type.FoundKafkaById).setLastTransitionGeneration(generation)
+            .setReason("").setMessage("").setStatus(KafkaCondition.Status.Unknown),
+        new KafkaCondition().setLastTransitionTime(isoNow()).setLastTransitionGeneration(generation)
+            .setReason("").setMessage("").setType(KafkaCondition.Type.Finished)
             .setStatus(Status.Unknown));
   }
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/KafkaConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/KafkaConnectionController.java
@@ -15,9 +15,11 @@ public class KafkaConnectionController extends AbstractCloudServicesController<K
 
   private static final Logger LOG = Logger.getLogger(KafkaConnectionController.class.getName());
 
-  @Inject KafkaApiClient apiClient;
+  @Inject
+  KafkaApiClient apiClient;
 
-  @Inject AccessTokenSecretTool accessTokenSecretTool;
+  @Inject
+  AccessTokenSecretTool accessTokenSecretTool;
 
   @Override
   void doCreateOrUpdateResource(KafkaConnection resource, Context<KafkaConnection> context)
@@ -48,11 +50,10 @@ public class KafkaConnectionController extends AbstractCloudServicesController<K
 
   void validateResource(KafkaConnection resource) throws InvalidUserInputException {
     ConditionUtil.assertNotNull(resource.getSpec(), "spec");
-    ConditionUtil.assertNotNull(
-        resource.getSpec().getAccessTokenSecretName(), "spec.accessTokenSecretName");
+    ConditionUtil.assertNotNull(resource.getSpec().getAccessTokenSecretName(),
+        "spec.accessTokenSecretName");
     ConditionUtil.assertNotNull(resource.getSpec().getCredentials(), "spec.credentials");
-    ConditionUtil.assertNotNull(
-        resource.getSpec().getCredentials().getServiceAccountSecretName(),
+    ConditionUtil.assertNotNull(resource.getSpec().getCredentials().getServiceAccountSecretName(),
         "spec.credentials.serviceAccountSecretName");
     ConditionUtil.assertNotNull(resource.getSpec().getKafkaId(), "spec.kafkaId");
     ConditionUtil.assertNotNull(resource.getMetadata().getNamespace(), "metadata.namespace");

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/CloudServiceAccountRequestTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/CloudServiceAccountRequestTest.java
@@ -26,51 +26,38 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 public class CloudServiceAccountRequestTest {
 
-  @QuarkusKubernetesMockServer KubernetesServer server;
+  @QuarkusKubernetesMockServer
+  KubernetesServer server;
 
-  @Inject CloudServiceAccountRequestController controller;
+  @Inject
+  CloudServiceAccountRequestController controller;
 
   /** Adds a secret to the k8s mock server */
   @BeforeEach
   public void setSecret() {
-    var secret =
-        new SecretBuilder()
-            .withNewMetadata()
-            .withNamespace("test")
-            .withName("rh-managed-services-api-accesstoken")
-            .endMetadata()
-            .addToData(Map.of("value", "bXl0b2tlbg=="));
+    var secret = new SecretBuilder().withNewMetadata().withNamespace("test")
+        .withName("rh-managed-services-api-accesstoken").endMetadata()
+        .addToData(Map.of("value", "bXl0b2tlbg=="));
 
-    server
-        .expect()
-        .get()
+    server.expect().get()
         .withPath("/api/v1/namespaces/test/secrets/rh-managed-services-api-accesstoken")
-        .andReturn(HttpURLConnection.HTTP_OK, secret.build())
-        .once();
+        .andReturn(HttpURLConnection.HTTP_OK, secret.build()).once();
   }
 
   @Test
   public void testCSARGoldenScenario() {
-    var csar =
-        new CloudServiceAccountRequestBuilder()
-            .withMetadata(
-                new ObjectMetaBuilder()
-                    .withGeneration(10l)
-                    .withNamespace("test")
-                    .withName("csr-test")
-                    .build())
-            .withSpec(
-                new CloudServiceAccountRequestSpecBuilder()
-                    .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
-                    .withNewServiceAccountDescription("Sample Description")
-                    .withNewServiceAccountName("accountName")
-                    .withNewServiceAccountSecretName("accountSecret")
-                    .build())
-            .build();
+    var csar = new CloudServiceAccountRequestBuilder()
+        .withMetadata(new ObjectMetaBuilder().withGeneration(10l).withNamespace("test")
+            .withName("csr-test").build())
+        .withSpec(new CloudServiceAccountRequestSpecBuilder()
+            .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
+            .withNewServiceAccountDescription("Sample Description")
+            .withNewServiceAccountName("accountName")
+            .withNewServiceAccountSecretName("accountSecret").build())
+        .build();
 
-    var result =
-        controller.createOrUpdateResource(
-            csar, EmptyContext.emptyContext(CloudServiceAccountRequest.class));
+    var result = controller.createOrUpdateResource(csar,
+        EmptyContext.emptyContext(CloudServiceAccountRequest.class));
 
     Assertions.assertTrue(result.isUpdateStatusSubResource());
   }

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/CloudServicesRequestControllerTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/CloudServicesRequestControllerTest.java
@@ -38,28 +38,24 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 public class CloudServicesRequestControllerTest {
 
-  @QuarkusKubernetesMockServer KubernetesServer server;
+  @QuarkusKubernetesMockServer
+  KubernetesServer server;
 
-  @Inject CloudServicesRequestController controller;
-  @Inject MockKafkaApiClient mockKafkaApiClient;
+  @Inject
+  CloudServicesRequestController controller;
+  @Inject
+  MockKafkaApiClient mockKafkaApiClient;
 
   /** Adds a secret to the k8s mock server */
   @BeforeEach
   public void setSecret() {
-    var secret =
-        new SecretBuilder()
-            .withNewMetadata()
-            .withNamespace("test")
-            .withName("rh-managed-services-api-accesstoken")
-            .endMetadata()
-            .addToData(Map.of("value", "bXl0b2tlbg=="));
+    var secret = new SecretBuilder().withNewMetadata().withNamespace("test")
+        .withName("rh-managed-services-api-accesstoken").endMetadata()
+        .addToData(Map.of("value", "bXl0b2tlbg=="));
 
-    server
-        .expect()
-        .get()
+    server.expect().get()
         .withPath("/api/v1/namespaces/test/secrets/rh-managed-services-api-accesstoken")
-        .andReturn(HttpURLConnection.HTTP_OK, secret.build())
-        .once();
+        .andReturn(HttpURLConnection.HTTP_OK, secret.build()).once();
   }
 
   @AfterEach
@@ -69,20 +65,13 @@ public class CloudServicesRequestControllerTest {
 
   @Test
   public void testCloudServicesRequest() {
-    var cloudServicesRequest =
-        new CloudServicesRequestBuilder()
-            .withMetadata(
-                new ObjectMetaBuilder()
-                    .withGeneration(10l)
-                    .withNamespace("test")
-                    .withName("csr-test")
-                    .build())
-            .withSpec(new CloudServicesRequestSpec("rh-managed-services-api-accesstoken"))
-            .build();
+    var cloudServicesRequest = new CloudServicesRequestBuilder()
+        .withMetadata(new ObjectMetaBuilder().withGeneration(10l).withNamespace("test")
+            .withName("csr-test").build())
+        .withSpec(new CloudServicesRequestSpec("rh-managed-services-api-accesstoken")).build();
 
-    var result =
-        controller.createOrUpdateResource(
-            cloudServicesRequest, EmptyContext.emptyContext(CloudServicesRequest.class));
+    var result = controller.createOrUpdateResource(cloudServicesRequest,
+        EmptyContext.emptyContext(CloudServicesRequest.class));
 
     Assertions.assertNotNull(result);
     Assertions.assertNotNull(result.getCustomResource());
@@ -108,20 +97,13 @@ public class CloudServicesRequestControllerTest {
    * likely fixed.
    */
   public void userKafkasUpdate() {
-    var cloudServicesRequest =
-        new CloudServicesRequestBuilder()
-            .withMetadata(
-                new ObjectMetaBuilder()
-                    .withGeneration(10l)
-                    .withNamespace("test")
-                    .withName("csr-test")
-                    .build())
-            .withSpec(new CloudServicesRequestSpec("rh-managed-services-api-accesstoken"))
-            .build();
+    var cloudServicesRequest = new CloudServicesRequestBuilder()
+        .withMetadata(new ObjectMetaBuilder().withGeneration(10l).withNamespace("test")
+            .withName("csr-test").build())
+        .withSpec(new CloudServicesRequestSpec("rh-managed-services-api-accesstoken")).build();
 
-    var result =
-        controller.createOrUpdateResource(
-            cloudServicesRequest, EmptyContext.emptyContext(CloudServicesRequest.class));
+    var result = controller.createOrUpdateResource(cloudServicesRequest,
+        EmptyContext.emptyContext(CloudServicesRequest.class));
 
     UserKafka userKafkas = (result.getCustomResource()).getStatus().getUserKafkas().get(0);
 
@@ -130,9 +112,8 @@ public class CloudServicesRequestControllerTest {
 
     cloudServicesRequest.getMetadata().setGeneration(11l);
 
-    result =
-        controller.createOrUpdateResource(
-            cloudServicesRequest, EmptyContext.emptyContext(CloudServicesRequest.class));
+    result = controller.createOrUpdateResource(cloudServicesRequest,
+        EmptyContext.emptyContext(CloudServicesRequest.class));
 
     UserKafka userKafkas2 = (result.getCustomResource()).getStatus().getUserKafkas().get(0);
     assertEquals("status", userKafkas.getStatus());

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/ConditionUtilsTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/ConditionUtilsTest.java
@@ -17,8 +17,7 @@ public class ConditionUtilsTest {
 
     var resourceConditions = resource.getStatus().getConditions();
 
-    Assertions.assertEquals(
-        KafkaCondition.Status.Unknown,
+    Assertions.assertEquals(KafkaCondition.Status.Unknown,
         ConditionUtil.getCondition(resourceConditions, KafkaCondition.Type.Finished).getStatus());
   }
 
@@ -30,18 +29,12 @@ public class ConditionUtilsTest {
 
     var resourceConditions = resource.getStatus().getConditions();
 
-    var exception =
-        new ConditionAwareException(
-            "Test Exception please Igrnore",
-            new RuntimeException(),
-            KafkaCondition.Type.AcccesTokenSecretValid,
-            KafkaCondition.Status.False,
-            "Ignore",
-            "Ignore");
+    var exception = new ConditionAwareException("Test Exception please Igrnore",
+        new RuntimeException(), KafkaCondition.Type.AcccesTokenSecretValid,
+        KafkaCondition.Status.False, "Ignore", "Ignore");
     ConditionUtil.setConditionFromException(resourceConditions, exception);
 
-    Assertions.assertEquals(
-        KafkaCondition.Status.False,
+    Assertions.assertEquals(KafkaCondition.Status.False,
         ConditionUtil.getCondition(resourceConditions, KafkaCondition.Type.Finished).getStatus());
   }
 }

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/KafkaConnectionControllerTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/KafkaConnectionControllerTest.java
@@ -33,49 +33,35 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 public class KafkaConnectionControllerTest {
 
-  @QuarkusKubernetesMockServer KubernetesServer server;
+  @QuarkusKubernetesMockServer
+  KubernetesServer server;
 
-  @Inject KafkaConnectionController controller;
+  @Inject
+  KafkaConnectionController controller;
 
   /** Adds a secret to the k8s mock server */
   @BeforeEach
   public void setSecret() {
-    var secret =
-        new SecretBuilder()
-            .withNewMetadata()
-            .withNamespace("test")
-            .withName("rh-managed-services-api-accesstoken")
-            .endMetadata()
-            .addToData(Map.of("value", "bXl0b2tlbg=="));
+    var secret = new SecretBuilder().withNewMetadata().withNamespace("test")
+        .withName("rh-managed-services-api-accesstoken").endMetadata()
+        .addToData(Map.of("value", "bXl0b2tlbg=="));
 
-    server
-        .expect()
-        .get()
+    server.expect().get()
         .withPath("/api/v1/namespaces/test/secrets/rh-managed-services-api-accesstoken")
-        .andReturn(HttpURLConnection.HTTP_OK, secret.build())
-        .once();
+        .andReturn(HttpURLConnection.HTTP_OK, secret.build()).once();
   }
 
   @Test
   public void testKafkaConnectionRequest() {
-    var kafkaConnectionRequest =
-        new KafkaConnectionBuilder()
-            .withMetadata(
-                new ObjectMetaBuilder()
-                    .withGeneration(10l)
-                    .withNamespace("test")
-                    .withName("kc-test")
-                    .build())
-            .withSpec(
-                new KafkaConnectionSpecBuilder()
-                    .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
-                    .withCredentials(new Credentials("sa-secret"))
-                    .withKafkaId("1234567890")
-                    .build())
-            .build();
-    var result =
-        controller.createOrUpdateResource(
-            kafkaConnectionRequest, EmptyContext.emptyContext(KafkaConnection.class));
+    var kafkaConnectionRequest = new KafkaConnectionBuilder()
+        .withMetadata(new ObjectMetaBuilder().withGeneration(10l).withNamespace("test")
+            .withName("kc-test").build())
+        .withSpec(new KafkaConnectionSpecBuilder()
+            .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
+            .withCredentials(new Credentials("sa-secret")).withKafkaId("1234567890").build())
+        .build();
+    var result = controller.createOrUpdateResource(kafkaConnectionRequest,
+        EmptyContext.emptyContext(KafkaConnection.class));
 
     Assertions.assertNotNull(result);
     Assertions.assertNotNull(result.getCustomResource());
@@ -93,8 +79,7 @@ public class KafkaConnectionControllerTest {
     var metaData = status.getMetadata();
     assertEquals("PLAIN", metaData.get("saslMechanism"));
     assertEquals("SASL_SSL", metaData.get("securityProtocol"));
-    assertEquals(
-        "https://cloud.redhat.com/beta/application-services/streams/kafkas/1234567890",
+    assertEquals("https://cloud.redhat.com/beta/application-services/streams/kafkas/1234567890",
         metaData.get("cloudUI"));
     assertEquals("rhoas", metaData.get("provider"));
     assertEquals("kafka", metaData.get("type"));

--- a/source/test/src/main/java/org/bf2/test/Environment.java
+++ b/source/test/src/main/java/org/bf2/test/Environment.java
@@ -57,28 +57,15 @@ public class Environment {
           .resolve("test-run-" + DATE_FORMAT.format(LocalDateTime.now()));
   public static final Path ROOT_PATH =
       Paths.get(System.getProperty("user.dir")).getParent().getParent();
-  public static final Path YAML_BUNDLE_PATH =
-      getOrDefault(
-          YAML_BUNDLE_PATH_ENV,
-          Paths::get,
-          Paths.get(ROOT_PATH.toString(), "operator", "src", "main", "kubernetes"));
-  public static final List<Path> CRDS_PATH =
-      List.of(
-          ROOT_PATH
-              .resolve("olm")
-              .resolve("olm-template")
-              .resolve("manifests")
-              .resolve("rhoas-operator.cloudservicesrequests.crd.yaml"),
-          ROOT_PATH
-              .resolve("olm")
-              .resolve("olm-template")
-              .resolve("manifests")
-              .resolve("rhoas-operator.cloudserviceaccountrequest.crd.yaml"),
-          ROOT_PATH
-              .resolve("olm")
-              .resolve("olm-template")
-              .resolve("manifests")
-              .resolve("rhoas-operator.kafkaconnections.crd.yaml"));
+  public static final Path YAML_BUNDLE_PATH = getOrDefault(YAML_BUNDLE_PATH_ENV, Paths::get,
+      Paths.get(ROOT_PATH.toString(), "operator", "src", "main", "kubernetes"));
+  public static final List<Path> CRDS_PATH = List.of(
+      ROOT_PATH.resolve("olm").resolve("olm-template").resolve("manifests")
+          .resolve("rhoas-operator.cloudservicesrequests.crd.yaml"),
+      ROOT_PATH.resolve("olm").resolve("olm-template").resolve("manifests")
+          .resolve("rhoas-operator.cloudserviceaccountrequest.crd.yaml"),
+      ROOT_PATH.resolve("olm").resolve("olm-template").resolve("manifests")
+          .resolve("rhoas-operator.kafkaconnections.crd.yaml"));
 
   public static final String IMAGE =
       getOrDefault(OPERATOR_IMAGE_ENV, "localhost:5000/bf2/operator:latest");
@@ -131,12 +118,8 @@ public class Environment {
    * @return value of variable fin defined data type
    */
   private static <T> T getOrDefault(String var, Function<String, T> converter, T defaultValue) {
-    String value =
-        System.getenv(var) != null
-            ? System.getenv(var)
-            : (Objects.requireNonNull(JSON_DATA).get(var) != null
-                ? JSON_DATA.get(var).asText()
-                : null);
+    String value = System.getenv(var) != null ? System.getenv(var)
+        : (Objects.requireNonNull(JSON_DATA).get(var) != null ? JSON_DATA.get(var).asText() : null);
     T returnValue = defaultValue;
     if (value != null) {
       returnValue = converter.apply(value);
@@ -151,13 +134,8 @@ public class Environment {
    * @return json object with loaded variables
    */
   private static JsonNode loadConfigurationFile() {
-    config =
-        System.getenv()
-            .getOrDefault(
-                CONFIG_FILE_PATH_ENV,
-                Paths.get(System.getProperty("user.dir"), "config.json")
-                    .toAbsolutePath()
-                    .toString());
+    config = System.getenv().getOrDefault(CONFIG_FILE_PATH_ENV,
+        Paths.get(System.getProperty("user.dir"), "config.json").toAbsolutePath().toString());
     ObjectMapper mapper = new ObjectMapper();
     try {
       File jsonFile = new File(config).getAbsoluteFile();

--- a/source/test/src/main/java/org/bf2/test/TestUtils.java
+++ b/source/test/src/main/java/org/bf2/test/TestUtils.java
@@ -29,9 +29,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public class TestUtils {
   private static final Logger LOGGER = LogManager.getLogger(TestUtils.class);
 
-  public static long waitFor(
-      String description, long pollIntervalMs, long timeoutMs, BooleanSupplier ready) {
-    return waitFor(description, pollIntervalMs, timeoutMs, ready, () -> {});
+  public static long waitFor(String description, long pollIntervalMs, long timeoutMs,
+      BooleanSupplier ready) {
+    return waitFor(description, pollIntervalMs, timeoutMs, ready, () -> {
+    });
   }
 
   /**
@@ -44,12 +45,8 @@ public class TestUtils {
    * @param onTimeout lambda method which is called when timeout is reached
    * @return
    */
-  public static long waitFor(
-      String description,
-      long pollIntervalMs,
-      long timeoutMs,
-      BooleanSupplier ready,
-      Runnable onTimeout) {
+  public static long waitFor(String description, long pollIntervalMs, long timeoutMs,
+      BooleanSupplier ready, Runnable onTimeout) {
     LOGGER.debug("Waiting for {}", description);
     long deadline = System.currentTimeMillis() + timeoutMs;
     while (true) {
@@ -72,11 +69,8 @@ public class TestUtils {
       }
       long sleepTime = Math.min(pollIntervalMs, timeLeft);
       if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace(
-            "{} not ready, will try again in {} ms ({}ms till timeout)",
-            description,
-            sleepTime,
-            timeLeft);
+        LOGGER.trace("{} not ready, will try again in {} ms ({}ms till timeout)", description,
+            sleepTime, timeLeft);
       }
       try {
         Thread.sleep(sleepTime);
@@ -91,8 +85,7 @@ public class TestUtils {
     File yamlFile = File.createTempFile("temp-file", ".yaml");
 
     try (InputStream bais = (InputStream) URI.create(url).toURL().openConnection().getContent();
-        BufferedReader br =
-            new BufferedReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
+        BufferedReader br = new BufferedReader(new InputStreamReader(bais, StandardCharsets.UTF_8));
         OutputStreamWriter osw =
             new OutputStreamWriter(new FileOutputStream(yamlFile), StandardCharsets.UTF_8)) {
 
@@ -105,10 +98,8 @@ public class TestUtils {
       }
       String yaml = sb.toString();
       yaml = yaml.replaceAll("namespace: .*", "namespace: " + namespace);
-      yaml =
-          yaml.replace(
-              "securityContext:\n" + "        runAsNonRoot: true\n" + "        runAsUser: 65534",
-              "");
+      yaml = yaml.replace(
+          "securityContext:\n" + "        runAsNonRoot: true\n" + "        runAsUser: 65534", "");
       osw.write(yaml);
       return yamlFile;
 

--- a/source/test/src/main/java/org/bf2/test/executor/Exec.java
+++ b/source/test/src/main/java/org/bf2/test/executor/Exec.java
@@ -146,8 +146,8 @@ public class Exec {
    * @param logToOutput log output or not
    * @return execution results
    */
-  public static ExecResult exec(
-      String input, List<String> command, int timeout, boolean logToOutput) {
+  public static ExecResult exec(String input, List<String> command, int timeout,
+      boolean logToOutput) {
     return exec(input, command, Collections.emptySet(), timeout, logToOutput, true);
   }
 
@@ -159,8 +159,8 @@ public class Exec {
    * @param throwErrors throw error if exec fail
    * @return results
    */
-  public static ExecResult exec(
-      String input, List<String> command, int timeout, boolean logToOutput, boolean throwErrors) {
+  public static ExecResult exec(String input, List<String> command, int timeout,
+      boolean logToOutput, boolean throwErrors) {
     return exec(input, command, Collections.emptySet(), timeout, logToOutput, throwErrors);
   }
 
@@ -174,13 +174,8 @@ public class Exec {
    * @param throwErrors look for errors in output and throws exception if true
    * @return execution results
    */
-  public static ExecResult exec(
-      String input,
-      List<String> command,
-      Set<EnvVar> envVars,
-      int timeout,
-      boolean logToOutput,
-      boolean throwErrors) {
+  public static ExecResult exec(String input, List<String> command, Set<EnvVar> envVars,
+      int timeout, boolean logToOutput, boolean throwErrors) {
     int ret = 1;
     ExecResult execResult;
     try {
@@ -206,16 +201,9 @@ public class Exec {
       execResult = new ExecResult(ret, executor.out(), executor.err());
 
       if (throwErrors && ret != 0) {
-        String msg =
-            "`"
-                + join(" ", command)
-                + "` got status code "
-                + ret
-                + " and stderr:\n------\n"
-                + executor.stdErr
-                + "\n------\nand stdout:\n------\n"
-                + executor.stdOut
-                + "\n------";
+        String msg = "`" + join(" ", command) + "` got status code " + ret
+            + " and stderr:\n------\n" + executor.stdErr + "\n------\nand stdout:\n------\n"
+            + executor.stdOut + "\n------";
 
         Matcher matcher = ERROR_PATTERN.matcher(executor.err());
         KubeClusterException t = null;
@@ -268,10 +256,9 @@ public class Exec {
     ProcessBuilder builder = new ProcessBuilder();
     builder.command(commands);
     if (envVars != null) {
-      envVars.forEach(
-          e -> {
-            builder.environment().put(e.getName(), e.getValue());
-          });
+      envVars.forEach(e -> {
+        builder.environment().put(e.getName(), e.getValue());
+      });
     }
     builder.directory(new File(System.getProperty("user.dir")));
     process = builder.start();
@@ -346,11 +333,9 @@ public class Exec {
     if (logPath != null) {
       try {
         Files.createDirectories(logPath);
-        Files.write(
-            Paths.get(logPath.toString(), "stdOutput.log"),
+        Files.write(Paths.get(logPath.toString(), "stdOutput.log"),
             stdOut.getBytes(Charset.defaultCharset()));
-        Files.write(
-            Paths.get(logPath.toString(), "stdError.log"),
+        Files.write(Paths.get(logPath.toString(), "stdError.log"),
             stdErr.getBytes(Charset.defaultCharset()));
       } catch (Exception ex) {
         LOGGER.warn("Cannot save output of execution: " + ex.getMessage());
@@ -381,8 +366,7 @@ public class Exec {
    */
   public static String cutExecutorLog(String log) {
     if (log.length() > MAXIMUM_EXEC_LOG_CHARACTER_SIZE) {
-      LOGGER.warn(
-          "Executor log is too long. Going to strip it and print only first {} characters",
+      LOGGER.warn("Executor log is too long. Going to strip it and print only first {} characters",
           MAXIMUM_EXEC_LOG_CHARACTER_SIZE);
       return log.substring(0, MAXIMUM_EXEC_LOG_CHARACTER_SIZE);
     }
@@ -418,22 +402,20 @@ public class Exec {
      * @return return future string of output
      */
     public Future<String> read() {
-      return CompletableFuture.supplyAsync(
-          () -> {
-            try (Scanner scanner = new Scanner(is, StandardCharsets.UTF_8.name())) {
-              while (scanner.hasNextLine()) {
-                data.append(scanner.nextLine());
-                if (appendLineSeparator) {
-                  data.append(System.getProperty("line.separator"));
-                }
-              }
-              scanner.close();
-              return data.toString();
-            } catch (Exception e) {
-              throw new CompletionException(e);
+      return CompletableFuture.supplyAsync(() -> {
+        try (Scanner scanner = new Scanner(is, StandardCharsets.UTF_8.name())) {
+          while (scanner.hasNextLine()) {
+            data.append(scanner.nextLine());
+            if (appendLineSeparator) {
+              data.append(System.getProperty("line.separator"));
             }
-          },
-          runnable -> new Thread(runnable).start());
+          }
+          scanner.close();
+          return data.toString();
+        } catch (Exception e) {
+          throw new CompletionException(e);
+        }
+      }, runnable -> new Thread(runnable).start());
     }
   }
 }

--- a/source/test/src/main/java/org/bf2/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/source/test/src/main/java/org/bf2/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -1,6 +1,6 @@
 /*
- * Copyright Strimzi authors.
- * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ * Copyright Strimzi authors. License: Apache License 2.0 (see the file LICENSE or
+ * http://apache.org/licenses/LICENSE-2.0.html).
  */
 package org.bf2.test.k8s.cmdClient;
 
@@ -140,16 +140,14 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
     }
   }
 
-  private Map<File, ExecResult> execRecursive(
-      String subcommand, File[] files, Comparator<File> cmp) {
+  private Map<File, ExecResult> execRecursive(String subcommand, File[] files,
+      Comparator<File> cmp) {
     Map<File, ExecResult> execResults = new HashMap<>(25);
     for (File f : files) {
       if (f.isFile()) {
         if (f.getName().endsWith(".yaml")) {
-          execResults.put(
-              f,
-              Exec.exec(
-                  null, namespacedCommand(subcommand, "-f", f.getAbsolutePath()), 0, false, false));
+          execResults.put(f, Exec.exec(null,
+              namespacedCommand(subcommand, "-f", f.getAbsolutePath()), 0, false, false));
         }
       } else if (f.isDirectory()) {
         File[] children = f.listFiles();
@@ -220,8 +218,8 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
   @SuppressWarnings("unchecked")
   public K scaleByName(String kind, String name, int replicas) {
     try (Context context = defaultContext()) {
-      Exec.exec(
-          null, namespacedCommand("scale", kind, name, "--replicas", Integer.toString(replicas)));
+      Exec.exec(null,
+          namespacedCommand("scale", kind, name, "--replicas", Integer.toString(replicas)));
       return (K) this;
     }
   }
@@ -239,8 +237,8 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
   }
 
   @Override
-  public ExecResult execInPodContainer(
-      boolean logToOutput, String pod, String container, String... command) {
+  public ExecResult execInPodContainer(boolean logToOutput, String pod, String container,
+      String... command) {
     List<String> cmd = namespacedCommand("exec", pod, "-c", container, "--");
     cmd.addAll(asList(command));
     return Exec.exec(null, cmd, 0, logToOutput);
@@ -278,9 +276,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
   }
 
   enum ExType {
-    BREAK,
-    CONTINUE,
-    THROW
+    BREAK, CONTINUE, THROW
   }
 
   @SuppressWarnings("unchecked")
@@ -288,23 +284,18 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
     long timeoutMs = 570_000L;
     long pollMs = 1_000L;
     ObjectMapper mapper = new ObjectMapper();
-    TestUtils.waitFor(
-        resource + " " + name,
-        pollMs,
-        timeoutMs,
-        () -> {
-          try {
-            String jsonString =
-                Exec.exec(namespacedCommand("get", resource, name, "-o", "json")).out();
-            LOGGER.trace("{}", jsonString);
-            JsonNode actualObj = mapper.readTree(jsonString);
-            return condition.test(actualObj);
-          } catch (KubeClusterException.NotFound e) {
-            return false;
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    TestUtils.waitFor(resource + " " + name, pollMs, timeoutMs, () -> {
+      try {
+        String jsonString = Exec.exec(namespacedCommand("get", resource, name, "-o", "json")).out();
+        LOGGER.trace("{}", jsonString);
+        JsonNode actualObj = mapper.readTree(jsonString);
+        return condition.test(actualObj);
+      } catch (KubeClusterException.NotFound e) {
+        return false;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
     return (K) this;
   }
 
@@ -317,18 +308,14 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
   @Override
   @SuppressWarnings("unchecked")
   public K waitForResourceDeletion(String resourceType, String resourceName) {
-    TestUtils.waitFor(
-        resourceType + " " + resourceName + " removal",
-        1_000L,
-        480_000L,
-        () -> {
-          try {
-            get(resourceType, resourceName);
-            return false;
-          } catch (KubeClusterException.NotFound e) {
-            return true;
-          }
-        });
+    TestUtils.waitFor(resourceType + " " + resourceName + " removal", 1_000L, 480_000L, () -> {
+      try {
+        get(resourceType, resourceName);
+        return false;
+      } catch (KubeClusterException.NotFound e) {
+        return true;
+      }
+    });
     return (K) this;
   }
 
@@ -339,16 +326,10 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
 
   @Override
   public List<String> list(String resourceType) {
-    return asList(
-            Exec.exec(
-                    namespacedCommand(
-                        "get", resourceType, "-o", "jsonpath={range .items[*]}{.metadata.name} "))
-                .out()
-                .trim()
-                .split(" +"))
-        .stream()
-        .filter(s -> !s.trim().isEmpty())
-        .collect(Collectors.toList());
+    return asList(Exec.exec(
+        namespacedCommand("get", resourceType, "-o", "jsonpath={range .items[*]}{.metadata.name} "))
+        .out().trim().split(" +")).stream().filter(s -> !s.trim().isEmpty())
+            .collect(Collectors.toList());
   }
 
   @Override
@@ -396,23 +377,14 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
   }
 
   @Override
-  public String searchInLog(
-      String resourceType, String resourceName, long sinceSeconds, String... grepPattern) {
+  public String searchInLog(String resourceType, String resourceName, long sinceSeconds,
+      String... grepPattern) {
     try {
-      return Exec.exec(
-              "bash",
-              "-c",
-              join(
-                  " ",
-                  namespacedCommand(
-                      "logs",
-                      resourceType + "/" + resourceName,
-                      "--since=" + sinceSeconds + "s",
-                      "|",
-                      "grep",
-                      " -e " + join(" -e ", grepPattern),
-                      "-B",
-                      "1")))
+      return Exec.exec("bash", "-c",
+          join(" ",
+              namespacedCommand("logs", resourceType + "/" + resourceName,
+                  "--since=" + sinceSeconds + "s", "|", "grep", " -e " + join(" -e ", grepPattern),
+                  "-B", "1")))
           .out();
     } catch (KubeClusterException e) {
       if (e.result != null && e.result.returnCode() == 1) {
@@ -425,28 +397,14 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
   }
 
   @Override
-  public String searchInLog(
-      String resourceType,
-      String resourceName,
-      String resourceContainer,
-      long sinceSeconds,
-      String... grepPattern) {
+  public String searchInLog(String resourceType, String resourceName, String resourceContainer,
+      long sinceSeconds, String... grepPattern) {
     try {
-      return Exec.exec(
-              "bash",
-              "-c",
-              join(
-                  " ",
-                  namespacedCommand(
-                      "logs",
-                      resourceType + "/" + resourceName,
-                      "-c " + resourceContainer,
-                      "--since=" + sinceSeconds + "s",
-                      "|",
-                      "grep",
-                      " -e " + join(" -e ", grepPattern),
-                      "-B",
-                      "1")))
+      return Exec.exec("bash", "-c",
+          join(" ",
+              namespacedCommand("logs", resourceType + "/" + resourceName,
+                  "-c " + resourceContainer, "--since=" + sinceSeconds + "s", "|", "grep",
+                  " -e " + join(" -e ", grepPattern), "-B", "1")))
           .out();
     } catch (KubeClusterException e) {
       if (e.result != null && e.result.exitStatus()) {
@@ -459,16 +417,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>>
   }
 
   public List<String> listResourcesByLabel(String resourceType, String label) {
-    return asList(
-        Exec.exec(
-                namespacedCommand(
-                    "get",
-                    resourceType,
-                    "-l",
-                    label,
-                    "-o",
-                    "jsonpath={range .items[*]}{.metadata.name} "))
-            .out()
-            .split("\\s+"));
+    return asList(Exec.exec(namespacedCommand("get", resourceType, "-l", label, "-o",
+        "jsonpath={range .items[*]}{.metadata.name} ")).out().split("\\s+"));
   }
 }

--- a/source/test/src/main/java/org/bf2/test/k8s/cmdClient/KubeCmdClient.java
+++ b/source/test/src/main/java/org/bf2/test/k8s/cmdClient/KubeCmdClient.java
@@ -1,6 +1,6 @@
 /*
- * Copyright Strimzi authors.
- * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ * Copyright Strimzi authors. License: Apache License 2.0 (see the file LICENSE or
+ * http://apache.org/licenses/LICENSE-2.0.html).
  */
 package org.bf2.test.k8s.cmdClient;
 
@@ -99,8 +99,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
    */
   ExecResult execInPodContainer(String pod, String container, String... command);
 
-  ExecResult execInPodContainer(
-      boolean logToOutput, String pod, String container, String... command);
+  ExecResult execInPodContainer(boolean logToOutput, String pod, String container,
+      String... command);
 
   /**
    * Execute the given {@code command}.
@@ -192,8 +192,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
    * @param grepPattern Grep patterns for search
    * @return Grep result as string
    */
-  String searchInLog(
-      String resourceType, String resourceName, long sinceSeconds, String... grepPattern);
+  String searchInLog(String resourceType, String resourceName, long sinceSeconds,
+      String... grepPattern);
 
   /**
    * @param resourceType The type of resource
@@ -203,12 +203,8 @@ public interface KubeCmdClient<K extends KubeCmdClient<K>> {
    * @param grepPattern Grep patterns for search
    * @return Grep result as string
    */
-  String searchInLog(
-      String resourceType,
-      String resourceName,
-      String resourceContainer,
-      long sinceSeconds,
-      String... grepPattern);
+  String searchInLog(String resourceType, String resourceName, String resourceContainer,
+      long sinceSeconds, String... grepPattern);
 
   String getResourceAsJson(String resourceType, String resourceName);
 

--- a/source/test/src/main/java/org/bf2/test/k8s/cmdClient/Kubectl.java
+++ b/source/test/src/main/java/org/bf2/test/k8s/cmdClient/Kubectl.java
@@ -1,6 +1,6 @@
 /*
- * Copyright Strimzi authors.
- * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ * Copyright Strimzi authors. License: Apache License 2.0 (see the file LICENSE or
+ * http://apache.org/licenses/LICENSE-2.0.html).
  */
 package org.bf2.test.k8s.cmdClient;
 

--- a/source/test/src/main/java/org/bf2/test/k8s/cmdClient/Oc.java
+++ b/source/test/src/main/java/org/bf2/test/k8s/cmdClient/Oc.java
@@ -1,6 +1,6 @@
 /*
- * Copyright Strimzi authors.
- * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ * Copyright Strimzi authors. License: Apache License 2.0 (see the file LICENSE or
+ * http://apache.org/licenses/LICENSE-2.0.html).
  */
 package org.bf2.test.k8s.cmdClient;
 

--- a/source/test/src/main/java/org/bf2/test/mock/QuarkusKubeMockServer.java
+++ b/source/test/src/main/java/org/bf2/test/mock/QuarkusKubeMockServer.java
@@ -29,8 +29,8 @@ public class QuarkusKubeMockServer implements QuarkusTestResourceLifecycleManage
     server = createServer();
     server.before();
     try (NamespacedKubernetesClient client = server.getClient()) {
-      systemProps.put(
-          Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, client.getConfiguration().getMasterUrl());
+      systemProps.put(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY,
+          client.getConfiguration().getMasterUrl());
     }
 
     try {
@@ -53,18 +53,9 @@ public class QuarkusKubeMockServer implements QuarkusTestResourceLifecycleManage
   public void configureServer(KubernetesServer mockServer) throws FileNotFoundException {
     // initialize with the crd
     for (Path crdPath : Environment.CRDS_PATH) {
-      server
-          .getClient()
-          .load(new FileInputStream(crdPath.toString()))
-          .get()
-          .forEach(
-              crd ->
-                  server
-                      .getClient()
-                      .apiextensions()
-                      .v1()
-                      .customResourceDefinitions()
-                      .createOrReplace((CustomResourceDefinition) crd));
+      server.getClient().load(new FileInputStream(crdPath.toString())).get()
+          .forEach(crd -> server.getClient().apiextensions().v1().customResourceDefinitions()
+              .createOrReplace((CustomResourceDefinition) crd));
     }
   }
 

--- a/source/test/src/main/java/org/bf2/test/mock/QuarkusKubernetesMockServer.java
+++ b/source/test/src/main/java/org/bf2/test/mock/QuarkusKubernetesMockServer.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 /** Annotation for KubernetesServer property in test class where extension pass mock kube server */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface QuarkusKubernetesMockServer {}
+public @interface QuarkusKubernetesMockServer {
+}


### PR DESCRIPTION
We had been using a formatting plugin that was not compatible with Java 16; I have changed that plugin to one which is. For reference, we are using the Google coding style. The previous plugin use a commandline formatter provided by Google, this plugin uses the Google eclipse formatting rules. Any changes in formatting is an artifact of that change.