### PR TITLE
GitHub packlage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
 
     <name>RHOAS Operator</name>
     <url>http://cloud.redhat.com</url>
-
     <modules>
         <module>source/openapi</module>
         <module>source/model</module>
@@ -43,7 +42,13 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+    <distributionManagement>
+        <repository>
+          <id>github</id>
+          <name>GitHub OWNER Apache Maven Packages</name>
+          <url>https://maven.pkg.github.com/redhat-developer/app-services-operator</url>
+        </repository>
+     </distributionManagement>
     <properties>
         <java.version>11</java.version>
         <maven.compiler.source>11</maven.compiler.source>
@@ -63,6 +68,23 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 </plugin>
+            <plugin>
+                <groupId>net.nicoulaj.maven.plugins</groupId>
+                <artifactId>checksum-maven-plugin</artifactId>
+                <version>1.9</version>
+                <executions>
+                    <execution>
+                    <goals>
+                        <goal>artifacts</goal>
+                    </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                <algorithms>
+                    <algorithm>SHA-256</algorithm>
+                </algorithms>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/source/model/pom.xml
+++ b/source/model/pom.xml
@@ -32,7 +32,7 @@
     <repository>
       <id>github</id>
       <name>GitHub OWNER Apache Maven Packages</name>
-      <url>https://maven.pkg.github.com/secondsun/app-services-operator</url>
+      <url>https://maven.pkg.github.com/redhat-developer/app-services-operator</url>
     </repository>
  </distributionManagement>
   <dependencies>

--- a/source/model/pom.xml
+++ b/source/model/pom.xml
@@ -18,7 +18,6 @@
     <sundrio.version>0.24.1</sundrio.version>
     <fabric8.models.version>5.2.0</fabric8.models.version>
     <fabric8.crdgen.version>5.2.0</fabric8.crdgen.version>
-
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -29,6 +28,13 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub OWNER Apache Maven Packages</name>
+      <url>https://maven.pkg.github.com/secondsun/app-services-operator</url>
+    </repository>
+ </distributionManagement>
   <dependencies>
         <dependency>
           <groupId>io.fabric8</groupId>
@@ -57,10 +63,27 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <version>1.9</version>
+        <executions>
+            <execution>
+            <goals>
+                <goal>artifacts</goal>
+            </goals>
+            </execution>
+        </executions>
+        <configuration>
+        <algorithms>
+            <algorithm>SHA-256</algorithm>
+        </algorithms>
+        </configuration>
+    </plugin>
+      <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>2.8.2</version>
         <configuration>
-          <skip>true</skip>
+          
         </configuration>
       </plugin>
       <plugin>

--- a/source/openapi/pom.xml
+++ b/source/openapi/pom.xml
@@ -164,12 +164,42 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
+                <groupId>net.nicoulaj.maven.plugins</groupId>
+                <artifactId>checksum-maven-plugin</artifactId>
+                <version>1.9</version>
+                <executions>
+                    <execution>
+                    <goals>
+                        <goal>artifacts</goal>
+                    </goals>
+                    </execution>
+                </executions>
                 <configuration>
-                    <skip>true</skip>
+                <algorithms>
+                    <algorithm>SHA-256</algorithm>
+                </algorithms>
                 </configuration>
+            </plugin>
+
+             <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          
+        </configuration>
+             </plugin>
+             <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>1.0.8</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/source/openapi/pom.xml
+++ b/source/openapi/pom.xml
@@ -24,7 +24,13 @@
         <javax-ws-rs-api-version>2.1.1</javax-ws-rs-api-version>
 
     </properties>
-
+    <distributionManagement>
+        <repository>
+          <id>github</id>
+          <name>GitHub OWNER Apache Maven Packages</name>
+          <url>https://maven.pkg.github.com/redhat-developer/app-services-operator</url>
+        </repository>
+     </distributionManagement>
     <dependencies>
         <dependency>
             <groupId>io.swagger</groupId>
@@ -129,6 +135,7 @@
                             <configOptions>
                                 <modelPackage>com.openshift.cloud.api.kas.models</modelPackage>
                                 <apiPackage>com.openshift.cloud.api.kas</apiPackage>
+                                <invokerPackage>com.openshift.cloud.api.kas.invoker</invokerPackage>
                                 <dateLibrary>java8</dateLibrary>
                                 <licenseName>Apache-2.0</licenseName>
                                 <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0.txt</licenseUrl>
@@ -153,6 +160,7 @@
                             <configOptions>
                                 <modelPackage>com.openshift.cloud.api.srs.models</modelPackage>
                                 <apiPackage>com.openshift.cloud.api.srs</apiPackage>
+                                <invokerPackage>com.openshift.cloud.api.srs.invoker</invokerPackage>
                                 <dateLibrary>java8</dateLibrary>
                                 <licenseName>Apache-2.0</licenseName>
                                 <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0.txt</licenseUrl>

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/AccessTokenSecretTool.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/AccessTokenSecretTool.java
@@ -1,6 +1,6 @@
 package com.openshift.cloud.beans;
 
-import com.openshift.cloud.api.ApiException;
+import com.openshift.cloud.api.kas.invoker.ApiException;
 import com.openshift.cloud.controllers.ConditionAwareException;
 import com.openshift.cloud.controllers.ConditionUtil;
 import com.openshift.cloud.v1alpha.models.KafkaCondition;

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
@@ -1,9 +1,9 @@
 package com.openshift.cloud.beans;
 
-import com.openshift.cloud.api.ApiClient;
-import com.openshift.cloud.api.ApiException;
-import com.openshift.cloud.api.Configuration;
-import com.openshift.cloud.api.auth.HttpBearerAuth;
+import com.openshift.cloud.api.kas.invoker.ApiClient;
+import com.openshift.cloud.api.kas.invoker.ApiException;
+import com.openshift.cloud.api.kas.invoker.Configuration;
+import com.openshift.cloud.api.kas.invoker.auth.HttpBearerAuth;
 import com.openshift.cloud.api.kas.DefaultApi;
 import com.openshift.cloud.api.kas.models.KafkaRequest;
 import com.openshift.cloud.api.kas.models.KafkaRequestList;

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ConditionUtil.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ConditionUtil.java
@@ -5,7 +5,7 @@ import static com.openshift.cloud.v1alpha.models.KafkaCondition.Status.True;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.openshift.cloud.api.ApiException;
+import com.openshift.cloud.api.kas.invoker.ApiException;
 import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.*;
 import com.openshift.cloud.v1alpha.models.KafkaCondition.Status;


### PR DESCRIPTION
Not urgent, but there is a fix in this.
 * This PR enables mvn deploy for operapi and model projects
 *  This PR fixes a bug in the generation of the openapi client. I had thought that the common Default client etc was shared. It is not and there are differences between the two. This generates separate clients and fixes the current kas only code to use the kas clients.