### PR TITLE
chore: remove quickstarts from installation phase

### DIFF
--- a/olm/autoupdate.sh
+++ b/olm/autoupdate.sh
@@ -30,7 +30,6 @@ fi
 echo "Creating bundle"
 mkdir olm-catalog/rhoas-operator/$version
 cp -r olm-template/* olm-catalog/rhoas-operator/$version
-cp -r quickstarts/*.yaml olm-catalog/rhoas-operator/$version/manifests
 
 sed -i "s/{{version}}/$version/g" olm-catalog/rhoas-operator/$version/manifests/rhoas-operator.clusterserviceversion.yaml 
 sed -i "s/{{organization}}/$3/g" olm-catalog/rhoas-operator/$version/manifests/rhoas-operator.clusterserviceversion.yaml 

--- a/olm/quickstarts/README.md
+++ b/olm/quickstarts/README.md
@@ -6,10 +6,10 @@ Quickstarts available as part of this operator.
 
 Add all Quick Starts to your OpenShift cluster
 ```
-oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-guides/main/devsandbox-quickstarts/rhosak-devsandbox-connect-cli-toolscontainer-quickstart.yaml
-oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-guides/main/devsandbox-quickstarts/rhosak-devsandbox-getting-started-quickstart.yaml
-oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-guides/main/devsandbox-quickstarts/rhosak-devsandbox-kafkacat-toolscontainer-quickstart.yaml
-oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-guides/main/devsandbox-quickstarts/rhosak-devsandbox-quarkus-bind-cli-toolscontainer-quickstart.yaml
+oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-operator/quickstarts/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
+oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-operator/quickstarts/olm/quickstarts/rhosak-openshift-getting-started-quickstart.yaml
+oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-operator/quickstarts/olm/quickstarts/rhosak-openshift-kafkacat-quickstart.yaml
+oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-operator/quickstarts/olm/quickstarts/rhosak-openshift-quarkus-bind-quickstart.yaml
 ```
 
 After installation go to right top corner `?` icon and select `Quickstarts` to view new Quickstarts that were added.


### PR DESCRIPTION
Disabling inclusion of quickstarts till we will know how to do it. 

Created separate bug for the work #230 