### PR TITLE
Docs: refine the connect and bind quick starts

### DIFF
--- a/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
+++ b/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
@@ -3,7 +3,7 @@ kind: ConsoleQuickStart
 metadata:
   name: rhosak-devsandbox-connect-cli-toolscontainer-quickstart
 spec:
-  displayName: Connecting OpenShift to Streams for Apache Kafka using the CLI
+  displayName: Connecting OpenShift to Red Hat OpenShift Streams for Apache Kafka using the CLI
   tags:
     - streams
     - kafka
@@ -11,95 +11,64 @@ spec:
   description: Connecting an OpenShift project to Red Hat OpenShift Streams for Apache Kafka using the RHOAS CLI
   prerequisites:
     - You have a Red Hat account.
-    - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/^) and the instance is in the *Ready* state.
-    - You have cluster administrator access for your OpenShift cluster.
+    - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/) and the instance is in the **Ready** state.
+    - You can log in to your OpenShift cluster with the `dedicated-admin` role (OpenShift Dedicated) or `cluster-admin` role.
+
   introduction: |-
     ### This quick start shows how to use the Red Hat OpenShift Application Services (RHOAS) CLI to connect a project in an OpenShift cluster to Red Hat OpenShift Streams for Apache Kafka.
 
-    As a developer of applications and services, there might be cases where you need to connect OpenShift applications to Kafka instances in Streams for Apache Kafka. Connecting an OpenShift application to a backing service such as Streams for Apache Kafka is called *service binding*.
+    As a developer of applications and services, there might be cases where you need to connect applications running on OpenShift to Kafka instances in Streams for Apache Kafka. Using an Operator to provide an application on OpenShift with the parameters required to connect to a Kafka instance in Streams for Apache Kafka is called *service binding*.
 
-    Before you can bind an OpenShift application to a Kafka instance, you need to connect the Kafka instance to the appropriate project in your OpenShift cluster. To make this connection, you can use the Red Hat OpenShift Application Services (RHOAS) Operator and CLI.
+    Before you can bind an application on OpenShift to a Kafka instance, you need to connect the Kafka instance to the appropriate project in your OpenShift cluster. To make this connection, you can use the Red Hat OpenShift Application Services (RHOAS) Operator and CLI.
 
     #### Prerequisites
     - You have a Red Hat account.
-    - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/^) and the instance is in the *Ready* state.
-    - You have cluster administrator access for your OpenShift cluster.
+    - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/) and the instance is in the **Ready** state.
+    - You can log in to your OpenShift cluster with the `dedicated-admin` role (OpenShift Dedicated) or `cluster-admin` role.
 
   tasks:
-    - title: Installing the RHOAS Operator
+    - title: Installing the required CLI tools
       description: |-
-          The Red Hat OpenShift Application Services (RHOAS) Operator enables you to expose Kafka instances in Streams for Apache Kafka to separate OpenShift clusters.
+        In this task, you'll use an image provided by Red Hat to install the CLI tools required to complete the quick start. Specifically, you'll install the following tools in a project in your OpenShift cluster:
 
-          When you install the Operator in an OpenShift cluster, you can use the RHOAS CLI to connect a specified Kafka instance to the cluster. You can then work directly with the Kafka instance using standard OpenShift features and APIs.
+        * The Red Hat OpenShift Application Services (RHOAS) CLI (`rhoas`)
+        * The OpenShift CLI (`oc`)
+        * The OpenShift Developer CLI (`odo`)
 
-          #### Prerequisites
-           - You have cluster administrator access for your OpenShift cluster.
+        Alternatively, you can install the CLI tools locally on your machine. See:
 
-          #### Procedure
+        * [Installing the RHOAS CLI](https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1/guide/f520e427-cad2-40ce-823d-96234ccbc047#_8818f0d5-ae20-42c8-9622-a98e663ff1a8)
+        * [Installing the OpenShift CLI](https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli)
+        * [Installing the OpenShift Developer CLI (odo)](https://docs.openshift.com/container-platform/4.7/cli_reference/developer_cli_odo/installing-odo.html)
 
-          1. Ensure that you are logged in to the OpenShift web console as a cluster administrator. If you are not logged in as a cluster administrator, log out, and then log back in. Then, resume this quick start.
+        **NOTE**: If you've installed the CLI tools locally on your machine, or you previously installed the image provided by Red Hat, you don't need to complete the remainder of this task. Click **Next** to skip to the next task in the quick start.
 
-          1. Click the [perspective switcher]{{highlight qs-perspective-switcher}}.  Switch to the **Administrator** perspective.
-
-          1. In the left menu, click **Operators** > **OperatorHub**.
-
-          1. In the **Filter by keyword** field, enter `RHOAS`.
-
-          1. Select the **OpenShift Application Services (RHOAS)** Operator.
-
-          1. If you see a dialog box entitled **Show community Operator**, review the included information. When you have finished, click **Continue**.
-             An information sidebar for the RHOAS Operator opens.
-
-          1. In the sidebar, review the information about the RHOAS Operator and then click **Install**.
-             The **Install Operator** page opens.
-
-          1. On the **Install Operator** page, for the **Installation mode** option, ensure that `All namespaces on the cluster` is selected. Keep all other default values.
-
-          1. Click **Install**.
-             When the installation process finishes, click **View Operator** to see the Operator details.
-             Observe that the RHOAS Operator is installed in the `openshift-operators` namespace by default.
-
-      review:
-        instructions: |-
-          #### Verify that you successfully installated the RHOAS Operator
-          Do you see the RHOAS Operator on the **Installed Operators** page?
-        failedTaskHelp: This task isn’t verified yet. Try the task again.
-
-      summary:
-        success: >-
-            You have successfully installed the RHOAS Operator. You are ready to install the required CLI tools.
-        failed: Try the steps again.
-
-    - title: Installing CLI tools
-      description: |-
-        When the RHOAS Operator is installed in your OpenShift cluster, you can use the RHOAS CLI to connect a Kafka instance in Streams for Apache Kafka to a project in the cluster. In this task, you use
-        a tools image provided by Red Hat to install the required CLI tools in your OpenShift project.
-
-        Alternatively, you can install the required CLI tools locally on your machine. See:
-          * [Installing the RHOAS CLI (rhoas)](https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1/guide/f520e427-cad2-40ce-823d-96234ccbc047#_8818f0d5-ae20-42c8-9622-a98e663ff1a8^)
-          * [Installing the OpenShift CLI (oc)](https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli^)
-          * [Installing the OpenShift Developer CLI (odo)](https://docs.openshift.com/container-platform/4.7/cli_reference/developer_cli_odo/installing-odo.html^)
-
-        **NOTE**: If you've installed the CLI tools on your machine, or you previously installed the tools image provided by Red Hat, click **Next** to skip to the next task in this quick start.
+        #### Prerequisites
+         - You can log in to your OpenShift cluster with privileges to create a new project.
 
         #### Procedure
 
+        1. Ensure that you're logged in to the OpenShift web console as a user that has privileges to create a new project in the cluster.
+
         1. Click the [perspective switcher]{{highlight qs-perspective-switcher}}. Switch to the **Developer** perspective.
+           The **Topology** page opens.
 
-        1. Click the **Project** drop-down menu at the top of the page. Select **Create Project**.
+        1. Create a new project.
 
-            i. In the **Name** field of the **Create Project** dialog box, enter a unique name, for example, `my-project`.
+            i. At the top of the **Topology** page, click the **Project** drop-down menu. Select **Create Project**.
 
-            ii. (Optional) Add details for **Display name** and **Description**.
+            ii. In the **Name** field of the **Create Project** dialog box, enter a unique name, for example, `my-project`.
 
-            iii. Click **Create**.
+            iii. (Optional) Add details for **Display name** and **Description**.
 
-        1. Deploy the tools image provided by Red Hat.
+            iv. Click **Create**.
+
+        1. Deploy the CLI tools image provided by Red Hat.
 
             i. Click [Add]{{highlight qs-nav-add}}.
 
-            ii. Click **Container images**.
-                The **Deploy Image** page opens.
+            ii. On the **Add** page, click **Container images**.
+                 The **Deploy Image** page opens.
 
             iii. For the **Image name from external registry** option, enter `quay.io/rhosak/rhoas-tools`.
 
@@ -108,8 +77,8 @@ spec:
             v. Under **Advanced Options**, *deselect* the **Create a route to the Application** check box. For all other options, keep the default values.
 
             vi. Click **Create**.
-                  The [Topology]{{highlight qs-nav-topology}} page opens.
-                  You should see an icon for the tools application you created. The icon should include a dark blue circle, which indicates that OpenShift deployed the application successfully.
+                The **Topology** page opens.
+                You should see an icon for the tools application you created. After some time, the icon should have a dark blue circle. This indicates that OpenShift deployed the application successfully.
 
         1. Click the icon for the tools application.
            A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should see a single Pod, corresponding to the tools application.
@@ -126,102 +95,140 @@ spec:
       review:
         instructions: |-
           #### Verify that you successfully installed the CLI tools
-          Do you you see the RHOAS CLI help text in the terminal of the Pod for the tools application?
+           * Did you you see the RHOAS CLI help text in the terminal of the Pod for the tools application?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
 
       summary:
         success: >-
-          You have installed the required CLI tools. You are ready to connect you Kafka instance to your OpenShift cluster.
+            You've installed the required CLI tools. You're ready to verify connection between the RHOAS Operator and your OpenShift cluster.
         failed: Try the steps again.
 
-    - title: Verifying RHOAS Operator connection to your OpenShift cluster
+    - title: Installing the RHOAS Operator
       description: |-
-        In previous tasks, you installed the RHOAS Operator and required CLI tools. You can now check whether the Operator is working by using the RHOAS CLI to connect to the OpenShift cluster and retrieve the cluster status.
+        The Red Hat OpenShift Application Services (RHOAS) Operator enables you to expose Kafka instances in Streams for Apache Kafka to OpenShift clusters.
+
+        In this task, you'll install the RHOAS Operator in your OpenShift cluster.
+
+        After you install the RHOAS Operator, you can use the RHOAS CLI to connect a specified Kafka instance to the cluster. You can then work directly with the Kafka instance using standard OpenShift features and APIs.
+
+        #### Prerequisites
+         - You can log in to your OpenShift cluster with the `dedicated-admin` role (OpenShift Dedicated) or `cluster-admin` role.
+
+        #### Procedure
+
+        1. Ensure that you're logged in to the OpenShift web console with the `dedicated-admin` role (OpenShift Dedicated) or `cluster-admin` role.
+
+        1. Click the [perspective switcher]{{highlight qs-perspective-switcher}}.  Switch to the **Administrator** perspective.
+
+        1. In the left menu, click **Operators** > **OperatorHub**.
+
+        1. In the **Filter by keyword** field, enter `RHOAS`.
+
+        1. Select the **OpenShift Application Services (RHOAS)** Operator.
+
+        1. If you see a dialog box entitled **Show community Operator**, review the included information. When you've finished, click **Continue**.
+           An information sidebar for the RHOAS Operator opens.
+
+          1. In the sidebar, review the information about the RHOAS Operator and then click **Install**.
+             The **Install Operator** page opens.
+
+        1. On the **Install Operator** page, for the **Installation mode** option, ensure that `All namespaces on the cluster` is selected. Keep all other default values.
+
+        1. Click **Install**.
+           When the installation process is finished, click **View Operator** to see the Operator details.
+           Observe that the RHOAS Operator is installed in the `openshift-operators` namespace by default.
+
+      review:
+        instructions: |-
+          #### Verify that you successfully installed the RHOAS Operator
+           * Is the RHOAS Operator listed on the **Installed Operators** page?
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+
+      summary:
+        success: >-
+            You've successfully installed the RHOAS Operator. You're now ready to install the CLI tools required to complete this quick start.
+        failed: Try the steps again.
+
+    - title: Checking RHOAS Operator connection to your OpenShift cluster
+      description: |-
+        In previous tasks, you installed the RHOAS Operator and required CLI tools. In this task, you'll check whether the RHOAS Operator is working by using the RHOAS CLI to connect to the OpenShift cluster and retrieve the cluster status.
 
         **NOTE**: By default, when you use the `rhoas login` command to log in to the RHOAS CLI, the CLI starts a sign-in flow in your web browser. However, the terminal in the Pod for your tools application does not have access to a browser. Therefore, in this task,
         you log in to the RHOAS CLI using a token.
 
         #### Prerequisites
+         - You've installed the required CLI tools.
          - You've installed the RHOAS Operator.
-         - You've installed the CLI tools.
-         - You have cluster administrator access for your OpenShift cluster.
 
         #### Procedure
 
-        1. Log in to your OpenShift cluster as a cluster administrator.
+        1. In your web browser, open the [OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token) page. Copy the access token shown.
 
-           ```
-           $ oc login -u <cluster-admin-user> -p <password> --server=<host:port>
-           ```
-           In the preceding example, replace the values in angle brackets (`< >`) with your own values.
+        1. In the OpenShift web console, click the [perspective switcher]{{highlight qs-perspective-switcher}}. Switch to the **Developer** perspective.
+           The **Topology** page opens.
 
-        1. Ensure that the current OpenShift project is the one you previously created. For example:
+        1. Ensure that the current OpenShift project is the one you created in the first task of this quick start.
 
-           ```
-           $ oc project my-project
-           ```
-        1. In your web browser, open the [OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token^) page. Copy the access token shown.
+            i. At the top of the **Topology** page, click the **Project** drop-down menu.
 
-        1. In the OpenShift web console, open the terminal of the Pod for your tools application, as described in the previous task.
+            ii. Select the project that you previously created.
+
+        1. Open the terminal of the Pod for your tools application, as described in the first task of this quick start.
 
         1. Log in to the RHOAS CLI using the token you copied.
 
            ```
-           rhoas login --token=<token>
+           $ rhoas login --token=<token>
            ```
            In the preceding example, replace `<token>` with the token value that you copied. To paste the value that you copied, right-click in the terminal window and select **Paste**.
 
-           When you press **Enter**, you should see a response confirming that you are logged in.
+           When you press **Enter**, you should see a response confirming that you're logged in.
 
-        1. Use the CLI to connect to your OpenShift cluster and retrieve the cluster status.
+        1. Use the RHOAS CLI to connect to your OpenShift cluster and retrieve the cluster status.
 
            ```
            $ rhoas cluster status
            Namespace: my-project
            RHOAS Operator: Installed
            ```
-           As shown in the output, the CLI indicates that the RHOAS Operator was successfully installed. The CLI also uses the RHOAS Operator to retrieve the name of the current OpenShift project (namespace). In this example, the current project is called `my-project`.
+           As shown in the output, the RHOAS CLI indicates that the RHOAS Operator was successfully installed. The CLI also retrieves the name of the current OpenShift project (namespace). In this example, the current project is called `my-project`.
 
       review:
         instructions: |-
           #### Verify connection between the RHOAS Operator and your OpenShift cluster
-          * Do you see `RHOAS Operator: Installed` when you execute the `rhoas cluster status` command?
-          * Do you see the current OpenShift namespace listed when you execute the `rhoas cluster status` command?
+          * Did you see `RHOAS Operator: Installed` when you executed the `rhoas cluster status` command?
+          * Did you see the current OpenShift namespace listed when you executed the `rhoas cluster status` command?
         failedTaskHelp: This task isn't verified yet. Try the task again.
       summary:
         success: >-
-          You've verified the RHOAS Operator is connected to your OpenShift cluster.
+          You've verified that the RHOAS Operator is connected to your OpenShift cluster. You're now ready to connect a Kafka instance to the cluster.
         failed: Try the steps again.
 
-    - title: Connecting a Kafka instance to your OpenShift cluster.
+    - title: Connecting a Kafka instance to your OpenShift cluster
       description: |
-        In previous tasks, you installed the required CLI tools and verified connection from the RHOAS Operator to your OpenShft cluster. You're now ready to connect a specified Kafka instance in Streams for Apache Kafka to the current project in your OpenShift cluster.
-
-        In this task, you'll use the RHOAS CLI to connect your Kafka instance to your OpenShift project.
+        In the previous task, you verified connection from the RHOAS Operator to your OpenShift cluster. You're now ready to connect a Kafka instance in Streams for Apache Kafka to the current project in the cluster.
 
         #### Prerequisites
 
-        - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/^) and the instance is in the *Ready* state.
+        - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/) and the instance is in the **Ready** state.
         - You've verified connection between the RHOAS Operator and your OpenShift cluster.
-        - You have an API token to connect to your Kafka instance. To get a token, see the [OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token^) page.
-        - You have privileges to create a new project in your OpenShift cluster.
+        - You have an API token to connect to your Kafka instance. To get a token, see the [OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token) page.
 
         #### Procedure
 
-        1. If you're not already logged in to your OpenShift cluster, log in as a user (for example, a cluster administrator) that has privileges to create a new project in the cluster. For example:
+        1. In the OpenShift web console, click the [perspective switcher]{{highlight qs-perspective-switcher}}. Ensure that you're using the **Developer** perspective.
 
-           ```
-           $ oc login -u <cluster-admin-user> -p <password> --server=<host:port>
-           ```
-           In the preceding example, replace the values in angle brackets (`< >`) with your own values.
+        1. Click [Topology]{{highlight qs-nav-topology}}.
 
-        1. Ensure that the current OpenShift project is the one created in the previous task. For example:
+        1. Ensure that the current OpenShift project is the one you created in the first task of this quick start.
 
-           ```
-           $ oc project my-project
-           ```
+            i. At the top of the **Topology** page, click the **Project** drop-down menu.
 
-        1. Connect a Kafka instance in Streams for Apache Kafka to the current project in your OpenShift cluster.
+            ii. Select the project that you previously created.
+
+        1. Open the terminal of the Pod for your tools application, as described in the first task of this quick start.
+
+        1. Use the RHOAS CLI to connect a Kafka instance in Streams for Apache Kafka to the current OpenShift project.
 
            ```
            $ rhoas cluster connect --ignore-context
@@ -238,13 +245,13 @@ spec:
            Service Account Secret: rh-cloud-services-service-account
            ```
 
-        1. Verify the connection details shown by the CLI. When you are ready to continue, type `y`. Then, press **Enter**.
+        1. Verify the connection details shown by the RHOAS CLI. When you're ready to continue, type `y`. Then, press **Enter**.
            You're prompted to provide an access token. The RHOAS Operator requires this token to make a connection to your Kafka instance.
 
         1. In your web browser, open the [OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token) page. Copy the access token shown.
 
         1. In your terminal window, right-click and select **Paste**. Press **Enter**.
-           The RHOAS Operator uses the token to create a **KafkaConnection** resource on your OpenShift cluster. When this process is complete, you should see lines like the following:
+           The RHOAS Operator uses the token to create a `KafkaConnection` resource on your OpenShift cluster. When this process is complete, you should see lines like the following:
 
            ```
            KafkaConnection resource "my-kafka-instance" has been created
@@ -254,7 +261,7 @@ spec:
            KafkaConnection successfully installed on your cluster.
            ```
 
-        1. Verify that the RHOAS Operator successfully created the connection.
+        1. Use the OpenShift CLI to verify that the RHOAS Operator successfully created the connection.
 
            ```
            $ oc get KafkaConnection
@@ -262,67 +269,79 @@ spec:
            NAME   		         AGE
            my-kafka-instance     2m35s
            ```
-           As shown in the output, the RHOAS Operator creates a **KafkaConnection** resource that matches the name of your Kafka instance. In this example, the resource name matches a Kafka instance called `my-kafka-instance`.
+           As shown in the output, the RHOAS Operator creates a `KafkaConnection` resource that matches the name of your Kafka instance. In this example, the resource name matches a Kafka instance called `my-kafka-instance`.
 
       review:
         instructions: |-
           #### Verify that you've successfully connected to a Kafka instance in Streams for Apache Kafka
-          Do you see a **KafkaConnection** resource listed when you execute the `oc get KafkaConnection` command?
+          * Did you see a `KafkaConnection` resource listed when you executed the `oc get KafkaConnection` command?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
         success: >-
           You've connected your Kafka instance to a project in your OpenShift cluster.
         failed: Try the steps again.
 
-    - title: Inspecting the Kafka connection details
+    - title: Inspecting the Kafka connection parameters
       description: |-
-        With your Kafka instance connected to a specified project in your OpenShift cluster, you're ready to bind applications in the project to the Kafka instance.
-        You can do this in different ways:
-        * Inspect the connection credentials for your Kafka instance and manually configure an application to connect to the instance.
-        * Use Operator functionality to bind your application to the the Kafka instance and have connection credentials automatically injected into your application.
+        With your Kafka instance connected to a project in your OpenShift cluster, you're ready to bind applications in the project to the Kafka instance.
+        In general, you can do this in one of these ways:
+        * Inspecting the connection parameters for your Kafka instance and manually configuring an application to connect to the instance.
+        * Using Operator functionality to bind your application to the the Kafka instance and having connection parameters automatically injected into the application.
 
-        In this task, you'll inspect the connection credentials required to *manually* connect an application to your Kafka instance.
+        In this task, you'll inspect the connection parameters required to *manually* connect an application to your Kafka instance.
 
         #### Prerequisites
-        You've connected your Kafka instance to a project in your OpenShift cluster.
+         - You've connected your Kafka instance to a project in your OpenShift cluster.
 
         #### Procedure
 
-        1. In your terminal, get the name of the **KafkaConnection** resource that you created in the previous task.
+        1. In the OpenShift web console, click the [perspective switcher]{{highlight qs-perspective-switcher}}. Ensure that you're using the the **Developer** perspective.
+
+        1. Click [Topology]{{highlight qs-nav-topology}}.
+
+        1. Ensure that the current OpenShift project is the one you created in the first task of this quick start.
+
+            i. At the top of the **Topology** page, click the **Project** drop-down menu.
+
+            ii. Select the project that you previously created.
+
+        1. Open the terminal of the Pod for your tools application, as described in the first task of this quick start.
+
+        1. Use the OpenShift CLI to get the name of the `KafkaConnection` resource created in the previous task.
 
            ```
            $ oc get KafkaConnection
            ```
 
-        1. Retrieve the details of the **KafkaConnection** resource.
+        1. Use the OpenShift CLI to retrieve the details of the `KafkaConnection` resource.
 
            ```
            $ oc describe KafkaConnection/<kafka-connection-name>
            ```
 
-           In the preceding example, replace `<kafka-connection-name>` with the name of your **KafkaConnection** resource. When you press **Enter**, the output shows comprehensive information for the **KafkaConnection** resource.
+           In the preceding example, replace `<kafka-connection-name>` with the name of your `KafkaConnection` resource. When you press **Enter**, the output shows detailed information for the `KafkaConnection` resource.
 
-        1. To manually configure an application to connect to the Kafka instance, collect the following required connection details:
+        1. To *manually* configure an application to connect to the Kafka instance, collect the following required connection details:
 
-            * **Bootstrap Server Host**. This the bootstrap server endpoint of the Kafka instance, in the format of `<host name>:<port>`.
+            * **Bootstrap Server Host**. This is the bootstrap server endpoint of the Kafka instance, in the format of `<host name>:<port>`.
             * **Sasl Mechanism**. This is the *Simple Authentication and Security Layer* (SASL) mechanism used by the Kafka instance for client authentication.
             * **Security Protocol**. This is the protocol used by the Kafka instance to secure client connections.
             * **Service Account Secret**. This secret contains the client ID and client secret required to connect to the Kafka instance.
 
       review:
         instructions: |-
-          #### Verify that you have collected the details required to manually configure an application to connect to your Kafka instance
+          #### Verify that you've collected the details required to manually configure an application to connect to your Kafka instance
           * Did you find the **Bootstrap Server Host** field, with a value in the format of `<host name>:<port>`?
           * Did you identify the authentication mechanism (`PLAIN` or `BEARER`) that the Kafka instance is using?
           * Did you identify the security mechanism (`SASL_PLAINTEXT` or `SASL_SSL`) that the Kafka instance is using?
-          * Did you find the name of the service account secret in which the client ID and client secret are stored?
+          * Did you find the name of the service account secret, in which the client ID and client secret are stored?
         failedTaskHelp: This task isn't verified yet. Try the task again.
       summary:
         success: >-
          You've collected the connection details you need to manually configure an application in your OpenShift project to connect to your Kafka instance.
         failed: Try the steps again.
   conclusion: >-
-    You've successfully connected a Kafka instance in Streams for Apache Kafka to a project in your OpenShift cluster.
-    You are now ready to bind to the Kafka instance from applications in the OpenShift project.
+    Congratulations! You successfully connected a Kafka instance in Streams for Apache Kafka to a project in your OpenShift cluster.
+    You're now ready to bind applications in the project to the Kafka instance.
   nextQuickStart:
     - rhosak-devsandbox-quarkus-bind-cli-toolscontainer-quickstart

--- a/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
+++ b/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
@@ -1,7 +1,7 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleQuickStart
 metadata:
-  name: rhosak-devsandbox-connect-cli-toolscontainer-quickstart-jbyrne
+  name: rhosak-devsandbox-connect-cli-toolscontainer-quickstart
 spec:
   displayName: Connecting OpenShift to Streams for Apache Kafka using the CLI
   tags:

--- a/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
+++ b/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
@@ -1,162 +1,328 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleQuickStart
 metadata:
-  name: rhosak-devsandbox-connect-cli-toolscontainer-quickstart
+  name: rhosak-devsandbox-connect-cli-toolscontainer-quickstart-jbyrne
 spec:
-  displayName: Connecting Red Hat OpenShift Streams for Apache Kafka to OpenShift
+  displayName: Connecting OpenShift to Streams for Apache Kafka using the CLI
   tags:
     - streams
     - kafka
   durationMinutes: 10
-  description: Using the OpenShift Streams for Apache Kafka cloud service in your OpenShift cluster
+  description: Connecting an OpenShift project to Red Hat OpenShift Streams for Apache Kafka using the RHOAS CLI
   prerequisites:
-    - Access to Red Hat OpenShift Streams for Apache Kafka (for more information, visit https://cloud.redhat.com/application-services).
-    - A running OpenShift Streams for Apache Kafka instance.
-  introduction: >-
-    ### This quick start shows you how to connect Red Hat OpenShift Streams for Apache Kafka to OpenShift using the RHOAS CLI.
+    - You have a Red Hat account.
+    - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/^) and the instance is in the *Ready* state.
+    - You have cluster administrator access for your OpenShift cluster.
+  introduction: |-
+    ### This quick start shows how to use the Red Hat OpenShift Application Services (RHOAS) CLI to connect a project in an OpenShift cluster to Red Hat OpenShift Streams for Apache Kafka.
 
-    In this Quick Start, you'll connect your OpenShift Streams for Apache Kafka cloud service to your OpenShift cluster using the Red Hat OpenShift Application Services
-    (RHOAS) Operator and CLI. For more information on Red Hat OpenShift Application Services, please visit [cloud.redhat.com.](https://cloud.redhat.com/application-services)
+    As a developer of applications and services, there might be cases where you need to connect OpenShift applications to Kafka instances in Streams for Apache Kafka. Connecting an OpenShift application to a backing service such as Streams for Apache Kafka is called *service binding*.
+
+    Before you can bind an OpenShift application to a Kafka instance, you need to connect the Kafka instance to the appropriate project in your OpenShift cluster. To make this connection, you can use the Red Hat OpenShift Application Services (RHOAS) Operator and CLI.
+
+    #### Prerequisites
+    - You have a Red Hat account.
+    - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/^) and the instance is in the *Ready* state.
+    - You have cluster administrator access for your OpenShift cluster.
+
   tasks:
-    - title: Access the required (CLI) Tools.
+    - title: Installing the RHOAS Operator
       description: |-
-        The Red Hat OpenShift Application Services operator allows you to represent Red Hat Cloud Services as first class citizens in your OpenShift environment.
-        This enables you to work and integrate with these services using standard OpenShift/Kubernetes features and APIs.
+          The Red Hat OpenShift Application Services (RHOAS) Operator enables you to expose Kafka instances in Streams for Apache Kafka to separate OpenShift clusters.
 
-        To connect your OpenShift project to your Red Hat OpenShift Application Services, you can use the RHOAS CLI. We've provided all the tools necessary to complete
-        this Quick Start in an image that you can deploy in your OpenShift project. Alternatively, you can install the RHOAS CLI, the OpenShift Client (oc),
-        and odo on your own machine. These tools can be downloaded from:
-          * oc: [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)
-          * RHOAS CLI: [https://github.com/redhat-developer/app-services-cli/releases/latest](https://github.com/redhat-developer/app-services-cli/releases/latest)
+          When you install the Operator in an OpenShift cluster, you can use the RHOAS CLI to connect a specified Kafka instance to the cluster. You can then work directly with the Kafka instance using standard OpenShift features and APIs.
 
-        To install the tooling image, do the following (if you are using your local installation of the RHOAS CLI, or if you've alread installed the tooling image in a previous Quick Start, you can skip these steps):
+          #### Prerequisites
+           - You have cluster administrator access for your OpenShift cluster.
 
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+          #### Procedure
 
-        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+          1. Ensure that you are logged in to the OpenShift web console as a cluster administrator. If you are not logged in as a cluster administrator, log out, and then log back in. Then, resume this quick start.
 
-        1. Make sure that your OpenShift **Project**, which you can see at the top of the **Add** window, is set to `{username}-dev` (where *{username}* is your username in the DevSandbox OpenShift environment).
+          1. Click the [perspective switcher]{{highlight qs-perspective-switcher}}.  Switch to the **Administrator** perspective.
 
-        1. Click on the **Container Image** card.
+          1. In the left menu, click **Operators** > **OperatorHub**.
 
-        1. In the **Image name from external registry** field, enter: `quay.io/rhosak/rhoas-tools`.
+          1. In the **Filter by keyword** field, enter `RHOAS`.
 
-        1. In the *Runtime icon* field, select `openshift`.
+          1. Select the **OpenShift Application Services (RHOAS)** Operator.
 
-        1. Uncheck the **Route** box and leave all other fields set to their default values.
-        You don't need a route for this application, so under the **Advanced Options** you can uncheck the **create a route to the Application** checkbox. 
-        Click the **Create** button. This will create a new OpenShift **Deployment** for the tools image.
+          1. If you see a dialog box entitled **Show community Operator**, review the included information. When you have finished, click **Continue**.
+             An information sidebar for the RHOAS Operator opens.
 
-        Pulling the container image and creating the container will take a couple of seconds.
+          1. In the sidebar, review the information about the RHOAS Operator and then click **Install**.
+             The **Install Operator** page opens.
 
-        1. You will see the deployment of the tools image in the [Topology]{{highlight qs-nav-add}} screen. The icon of the application should have a blue circle around it, indicating that the application has been deployed successfully.
+          1. On the **Install Operator** page, for the **Installation mode** option, ensure that `All namespaces on the cluster` is selected. Keep all other default values.
 
-        1. Click on the icon of the tools application. This will open a panel on the righ-hand-side of your screen.
-        Click on the **Resources** tab. You will see the **Pods** of your Deployment. Currently we only have a single pod.
-
-        1. Click on the link to the pod. This opens the details page of the pod.
-
-        1. Open the **Terminal** tab. This opens a terminal inside the pod. To check whether you can access the required tooling, execute the command `rhoas` in your terminal.
-        This should print the Red Hat OpenShift Application Services CLI help text.
+          1. Click **Install**.
+             When the installation process finishes, click **View Operator** to see the Operator details.
+             Observe that the RHOAS Operator is installed in the `openshift-operators` namespace by default.
 
       review:
         instructions: |-
-          #### Verify that you've successfully accessed the CLI tools:
-          Did you see the Red Hat OpenShift Application Services CLI help text in the terminal of the tooling pod?
+          #### Verify that you successfully installated the RHOAS Operator
+          Do you see the RHOAS Operator on the **Installed Operators** page?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
+
       summary:
         success: >-
-          Great work! You have access to the tooling required for the remainder of this quickstart.
+            You have successfully installed the RHOAS Operator. You are ready to install the required CLI tools.
         failed: Try the steps again.
 
-
-    - title: Connect your Red Hat OpenShift Application Services to your OpenShift instance.
+    - title: Installing CLI tools
       description: |-
-        With the tooling pod in place, you can connect your Red Hat OpenShift Streams for Apache Kafka instance to your OpenShift project/namespace.
+        When the RHOAS Operator is installed in your OpenShift cluster, you can use the RHOAS CLI to connect a Kafka instance in Streams for Apache Kafka to a project in the cluster. In this task, you use
+        a tools image provided by Red Hat to install the required CLI tools in your OpenShift project.
 
-        The Red Hat OpenShift Application Services operator allows you to represent Red Hat Cloud Services as first class citizens in your OpenShift environment.
-        This enables you to work and integrate with these services using standard OpenShift/Kubernetes features and APIs.
+        Alternatively, you can install the required CLI tools locally on your machine. See:
+          * [Installing the RHOAS CLI (rhoas)](https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1/guide/f520e427-cad2-40ce-823d-96234ccbc047#_8818f0d5-ae20-42c8-9622-a98e663ff1a8^)
+          * [Installing the OpenShift CLI (oc)](https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli^)
+          * [Installing the OpenShift Developer CLI (odo)](https://docs.openshift.com/container-platform/4.7/cli_reference/developer_cli_odo/installing-odo.html^)
 
-        We will use the `rhoas` CLI to connect your Kafka instance to your OpenShift project. The `rhoas` CLI uses a browser-based login flow by default
-        (meaning, when you execute `rhoas login` it will start a sign-in flow in your web browser). Since our terminal in OpenShift does not have access to a browser,
-        we need to login using a token.
+        **NOTE**: If you've installed the CLI tools on your machine, or you previously installed the tools image provided by Red Hat, click **Next** to skip to the next task in this quick start.
 
-        1. Navigate to [https://cloud.redhat.com/openshift/token](https://cloud.redhat.com/openshift/token) and copy the token to your clipboard using the **Copy to clipboard** button.
+        #### Procedure
 
-        1. In your terminal, execute the RHOAS CLI login command, replacing *{token}* with the token you've just copied to your clipboard: `rhoas login --token={token}`.
-        You should see a response saying: **You are now logged in as {user}**.
+        1. Click the [perspective switcher]{{highlight qs-perspective-switcher}}. Switch to the **Developer** perspective.
 
-        1. List your Kafka instances by executing the command: `rhoas kafka list`. You should see a Streams for Apache Kafka instance that has been provisioned for you.
+        1. Click the **Project** drop-down menu at the top of the page. Select **Create Project**.
 
-        The **rhoas** CLI uses the **oc** CLI to determine the OpenShift instance, and project, that the Streams for Apache Kafka instance should be connected to.
-        Let's verify that your **oc** client is properly connected to your OpenShift project.
+            i. In the **Name** field of the **Create Project** dialog box, enter a unique name, for example, `my-project`.
 
-        1. In your terminal, first login the **oc** client to our OpenShift instance. To do this:
-            1. Click on your username in the top-right of the OpenShift console and click **Copy login command**
-            1. A new tab opens in your browser with the OpenShift Developer Sandbox login screen. In the *Log in with...* box, select **DevSandbox**.
-            1. Click on **Display Token**.
-            1. Copy the `oc login` command.
-            1. Go to your terminal, and execute the command you just copied.
+            ii. (Optional) Add details for **Display name** and **Description**.
 
-        1. The output of the login command will state **Using project {project-name}**. This should be set to _*{username}-dev*.
-        If this is not the case, in your terminal, point your **oc** client to the correct OpenShift namespace/project (replace *{username}* with your username in the Developer Sandbox OpenShift environment): `oc project {username}-dev`.
+            iii. Click **Create**.
 
-        1. To connect your Kafka instance to your project, execute the following command in your terminal: `rhoas cluster connect`.
+        1. Deploy the tools image provided by Red Hat.
 
-        1. You are asked to select the Kafka instance you want to connect. Since you only have a single Kafka instance in your Red Hat Cloud Services, simply press **Enter** to continue.
+            i. Click [Add]{{highlight qs-nav-add}}.
 
-        1. The CLI will print the **Connection Details** and asks you to confirm. Type `y` and press **Enter** to continue.
+            ii. Click **Container images**.
+                The **Deploy Image** page opens.
 
-        1. You will be asked to provide a token, which again can be retrieved from https://cloud.redhat.com/openshift/token . Navigate to this URL again, copy the token to your clipboard, and copy it into your terminal. Press **Enter** to continue.
-        You should see the message: **KafkaConnection successfully installed on your cluster.**
+            iii. For the **Image name from external registry** option, enter `quay.io/rhosak/rhoas-tools`.
 
-        1. To verify that the connection has been successfully created, execute the following **oc** command: `oc get KafkaConnection`. This should return a **KafkaConnection** with the name of your Kafka instance.
+            iv. For the **Runtime icon** option, select `openshift`.
+
+            v. Under **Advanced Options**, *deselect* the **Create a route to the Application** check box. For all other options, keep the default values.
+
+            vi. Click **Create**.
+                  The [Topology]{{highlight qs-nav-topology}} page opens.
+                  You should see an icon for the tools application you created. The icon should include a dark blue circle, which indicates that OpenShift deployed the application successfully.
+
+        1. Click the icon for the tools application.
+           A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should see a single Pod, corresponding to the tools application.
+
+        1. Click the link to the Pod.
+           The **Pod details** page opens.
+
+        1. Click the **Terminal** tab.
+           A terminal window opens inside the Pod.
+
+        1. To check whether you can access the required tools, in the terminal, enter `rhoas`.
+           The `rhoas` command should show help text for the RHOAS CLI.
 
       review:
         instructions: |-
-          #### Verify that you've successfully connected to Red Hat OpenShift Application Services:
-          Did you see the your **KafkaConnection** listed when you executed the `oc get KafkaConnection` command?
+          #### Verify that you successfully installed the CLI tools
+          Do you you see the RHOAS CLI help text in the terminal of the Pod for the tools application?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
+
       summary:
         success: >-
-          Great work! You've connected you OpenShift project
-          to your **Red Hat OpenShift Application Services**.
+          You have installed the required CLI tools. You are ready to connect you Kafka instance to your OpenShift cluster.
         failed: Try the steps again.
 
-    - title: Inspect the Kafka connection details
+    - title: Verifying RHOAS Operator connection to your OpenShift cluster
       description: |-
-        With your Streams for Apache Kafka instance bound to your OpenShift project/namespace, you can now connect your application to it.
+        In previous tasks, you installed the RHOAS Operator and required CLI tools. You can now check whether the Operator is working by using the RHOAS CLI to connect to the OpenShift cluster and retrieve the cluster status.
 
-        This can be done in different ways.
-        * You can inspect the connection details of your Kafka instance and configure your application to connect to it.
-        * You can use OpenShift/Kubernetes Service Binding to bind your application to the service and have the connection details and credentials automatically injected into your application.
+        **NOTE**: By default, when you use the `rhoas login` command to log in to the RHOAS CLI, the CLI starts a sign-in flow in your web browser. However, the terminal in the Pod for your tools application does not have access to a browser. Therefore, in this task,
+        you log in to the RHOAS CLI using a token.
 
-        1. In your terminal, execute the following command to get the name of the **KafkaConnection** resource you've created in the previous task: `oc get KafkaConnection`.
-        This will list the **KafkaConnection** resources in your project.
+        #### Prerequisites
+         - You've installed the RHOAS Operator.
+         - You've installed the CLI tools.
+         - You have cluster administrator access for your OpenShift cluster.
 
-        1. Execute the following command to retrieve the details of your **KafkaConnection**. Replace *{kafka-connection-name}* with the name of your **KafkaConnection** resource: `oc describe KafkaConnection/{kafka-connection-name}`
+        #### Procedure
 
-        1. The output of the previous command contains the details of your **KafkaConnection**. Try to find the **Bootstrap Server Host** setting of your **KafkaConnection**.
+        1. Log in to your OpenShift cluster as a cluster administrator.
 
-        1. The **KafkaConnection** contains more information besides the **Bootstrap Server Host**. Try to find the **Sasl Mechanism** and the **Security Protocol**.
+           ```
+           $ oc login -u <cluster-admin-user> -p <password> --server=<host:port>
+           ```
+           In the preceding example, replace the values in angle brackets (`< >`) with your own values.
 
-        1. Finally the **KafkaConnection** has a reference to **Service Account Secret** that contains the **Client ID** and **Client Secret** needed to connect to the service. Try to find that configuration in your **KafkaConnection**.
+        1. Ensure that the current OpenShift project is the one you previously created. For example:
+
+           ```
+           $ oc project my-project
+           ```
+        1. In your web browser, open the [OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token^) page. Copy the access token shown.
+
+        1. In the OpenShift web console, open the terminal of the Pod for your tools application, as described in the previous task.
+
+        1. Log in to the RHOAS CLI using the token you copied.
+
+           ```
+           rhoas login --token=<token>
+           ```
+           In the preceding example, replace `<token>` with the token value that you copied. To paste the value that you copied, right-click in the terminal window and select **Paste**.
+
+           When you press **Enter**, you should see a response confirming that you are logged in.
+
+        1. Use the CLI to connect to your OpenShift cluster and retrieve the cluster status.
+
+           ```
+           $ rhoas cluster status
+           Namespace: my-project
+           RHOAS Operator: Installed
+           ```
+           As shown in the output, the CLI indicates that the RHOAS Operator was successfully installed. The CLI also uses the RHOAS Operator to retrieve the name of the current OpenShift project (namespace). In this example, the current project is called `my-project`.
 
       review:
         instructions: |-
-          #### You have all the necessary information to connect your application to your OpenShift Streams for Apache Kafka instance:
-          Have you seen the **Bootstrap Server Host** field with hostname and port?
-
-          Do you know which authentication mechanism (SASL/PLAIN, SASL/OAUTHBEARER) is used?
-
-          Do you know the name of the secret in which your **Client ID** and **Client Secret** are stored?
+          #### Verify connection between the RHOAS Operator and your OpenShift cluster
+          * Do you see `RHOAS Operator: Installed` when you execute the `rhoas cluster status` command?
+          * Do you see the current OpenShift namespace listed when you execute the `rhoas cluster status` command?
         failedTaskHelp: This task isn't verified yet. Try the task again.
       summary:
         success: >-
-          Great work! You've connected your Streams for Apache Kafka cloud service to your OpenShift project/namespace.
+          You've verified the RHOAS Operator is connected to your OpenShift cluster.
+        failed: Try the steps again.
+
+    - title: Connecting a Kafka instance to your OpenShift cluster.
+      description: |
+        In previous tasks, you installed the required CLI tools and verified connection from the RHOAS Operator to your OpenShft cluster. You're now ready to connect a specified Kafka instance in Streams for Apache Kafka to the current project in your OpenShift cluster.
+
+        In this task, you'll use the RHOAS CLI to connect your Kafka instance to your OpenShift project.
+
+        #### Prerequisites
+
+        - You’ve created a Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/^) and the instance is in the *Ready* state.
+        - You've verified connection between the RHOAS Operator and your OpenShift cluster.
+        - You have an API token to connect to your Kafka instance. To get a token, see the [OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token^) page.
+        - You have privileges to create a new project in your OpenShift cluster.
+
+        #### Procedure
+
+        1. If you're not already logged in to your OpenShift cluster, log in as a user (for example, a cluster administrator) that has privileges to create a new project in the cluster. For example:
+
+           ```
+           $ oc login -u <cluster-admin-user> -p <password> --server=<host:port>
+           ```
+           In the preceding example, replace the values in angle brackets (`< >`) with your own values.
+
+        1. Ensure that the current OpenShift project is the one created in the previous task. For example:
+
+           ```
+           $ oc project my-project
+           ```
+
+        1. Connect a Kafka instance in Streams for Apache Kafka to the current project in your OpenShift cluster.
+
+           ```
+           $ rhoas cluster connect --ignore-context
+           ```
+           You're prompted to specify the Kafka instance that you want to connect to OpenShift.
+
+        1. Type the name of the Kafka instance that you want to connect to OpenShift. Press **Enter**.
+           You should see output like the following:
+
+           ```
+           Connection Details:
+           Apache Kafka instance:  my-kafka-instance
+           Kubernetes Namespace:   my-project
+           Service Account Secret: rh-cloud-services-service-account
+           ```
+
+        1. Verify the connection details shown by the CLI. When you are ready to continue, type `y`. Then, press **Enter**.
+           You're prompted to provide an access token. The RHOAS Operator requires this token to make a connection to your Kafka instance.
+
+        1. In your web browser, open the [OpenShift Cluster Manager API Token](https://cloud.redhat.com/openshift/token) page. Copy the access token shown.
+
+        1. In your terminal window, right-click and select **Paste**. Press **Enter**.
+           The RHOAS Operator uses the token to create a **KafkaConnection** resource on your OpenShift cluster. When this process is complete, you should see lines like the following:
+
+           ```
+           KafkaConnection resource "my-kafka-instance" has been created
+           Waiting for status from KafkaConnection resource.
+           Created KafkaConnection can be injected into your application.
+           ...
+           KafkaConnection successfully installed on your cluster.
+           ```
+
+        1. Verify that the RHOAS Operator successfully created the connection.
+
+           ```
+           $ oc get KafkaConnection
+
+           NAME   		         AGE
+           my-kafka-instance     2m35s
+           ```
+           As shown in the output, the RHOAS Operator creates a **KafkaConnection** resource that matches the name of your Kafka instance. In this example, the resource name matches a Kafka instance called `my-kafka-instance`.
+
+      review:
+        instructions: |-
+          #### Verify that you've successfully connected to a Kafka instance in Streams for Apache Kafka
+          Do you see a **KafkaConnection** resource listed when you execute the `oc get KafkaConnection` command?
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: >-
+          You've connected your Kafka instance to a project in your OpenShift cluster.
+        failed: Try the steps again.
+
+    - title: Inspecting the Kafka connection details
+      description: |-
+        With your Kafka instance connected to a specified project in your OpenShift cluster, you're ready to bind applications in the project to the Kafka instance.
+        You can do this in different ways:
+        * Inspect the connection credentials for your Kafka instance and manually configure an application to connect to the instance.
+        * Use Operator functionality to bind your application to the the Kafka instance and have connection credentials automatically injected into your application.
+
+        In this task, you'll inspect the connection credentials required to *manually* connect an application to your Kafka instance.
+
+        #### Prerequisites
+        You've connected your Kafka instance to a project in your OpenShift cluster.
+
+        #### Procedure
+
+        1. In your terminal, get the name of the **KafkaConnection** resource that you created in the previous task.
+
+           ```
+           $ oc get KafkaConnection
+           ```
+
+        1. Retrieve the details of the **KafkaConnection** resource.
+
+           ```
+           $ oc describe KafkaConnection/<kafka-connection-name>
+           ```
+
+           In the preceding example, replace `<kafka-connection-name>` with the name of your **KafkaConnection** resource. When you press **Enter**, the output shows comprehensive information for the **KafkaConnection** resource.
+
+        1. To manually configure an application to connect to the Kafka instance, collect the following required connection details:
+
+            * **Bootstrap Server Host**. This the bootstrap server endpoint of the Kafka instance, in the format of `<host name>:<port>`.
+            * **Sasl Mechanism**. This is the *Simple Authentication and Security Layer* (SASL) mechanism used by the Kafka instance for client authentication.
+            * **Security Protocol**. This is the protocol used by the Kafka instance to secure client connections.
+            * **Service Account Secret**. This secret contains the client ID and client secret required to connect to the Kafka instance.
+
+      review:
+        instructions: |-
+          #### Verify that you have collected the details required to manually configure an application to connect to your Kafka instance
+          * Did you find the **Bootstrap Server Host** field, with a value in the format of `<host name>:<port>`?
+          * Did you identify the authentication mechanism (`PLAIN` or `BEARER`) that the Kafka instance is using?
+          * Did you identify the security mechanism (`SASL_PLAINTEXT` or `SASL_SSL`) that the Kafka instance is using?
+          * Did you find the name of the service account secret in which the client ID and client secret are stored?
+        failedTaskHelp: This task isn't verified yet. Try the task again.
+      summary:
+        success: >-
+         You've collected the connection details you need to manually configure an application in your OpenShift project to connect to your Kafka instance.
         failed: Try the steps again.
   conclusion: >-
-    You've successfully created a connection between a Red Hat managed cloud service and your OpenShift project/namespace.
-    You can now start using this Kafka instance in your applications, for example by binding the Kafka service to a Quarkus application.
+    You've successfully connected a Kafka instance in Streams for Apache Kafka to a project in your OpenShift cluster.
+    You are now ready to bind to the Kafka instance from applications in the OpenShift project.
   nextQuickStart:
     - rhosak-devsandbox-quarkus-bind-cli-toolscontainer-quickstart

--- a/olm/quickstarts/rhosak-openshift-quarkus-bind-quickstart.yaml
+++ b/olm/quickstarts/rhosak-openshift-quarkus-bind-quickstart.yaml
@@ -3,57 +3,62 @@ kind: ConsoleQuickStart
 metadata:
   name: rhosak-devsandbox-quarkus-bind-cli-toolscontainer-quickstart
 spec:
-  displayName: Binding a Quarkus application to Streams for Apache Kafka using the CLI
+  displayName: Binding an application to Red Hat OpenShift Streams for Apache Kafka using the CLI
   tags:
     - streams
     - kafka
     - quarkus
   durationMinutes: 10
-  description: Binding a Quarkus application to Streams for Apache Kafka using the CLI
+  description: Binding an application in OpenShift to Red Hat OpenShift Streams for Apache Kafka using the CLI
   prerequisites:
-    - You've completed the **Connecting an OpenShift project to Streams for Apache Kafka using the CLI** quick start.
+    - You've completed the **Connecting OpenShift to Streams for Apache Kafka using the CLI** quick start.
     - You have privileges to deploy applications in the OpenShift project that you connected your Kafka instance to.
-    - Your Kafka instance in Streams for Apache Kafka is in the **Ready** state.
+    - Your Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/) is in the **Ready** state.
 
   introduction: |-
-      ### This quick start shows how to use Red Hat OpenShift Application Services (RHOAS) CLI to the bind an example Quarkus application to a Kafka instance in Red Hat OpenShift Streams for Apache Kafka.
+      ### This quick start shows how to use the Red Hat OpenShift Application Services (RHOAS) CLI to the bind an example Quarkus application to a Kafka instance in Red Hat OpenShift Streams for Apache Kafka.
 
-      As a developer of applications and services, there might be cases where you need to connect OpenShift applications to Kafka instances in Streams for Apache Kafka. Connecting an OpenShift application to a backing service such as Streams for Apache Kafka is called *service binding*.
+      As a developer of applications and services, there might be cases where you need to connect OpenShift applications to Kafka instances in Streams for Apache Kafka. Using an Operator to provide an application on OpenShift with the parameters required to connect to a Kafka instance is called *service binding*.
 
-      In this quick start, you'll use the RHOAS CLI and Operator to bind an example Quarkus application to your Kafka instance. [Quarkus](https://quarkus.io/^) is a Kubernetes-native Java framework that is optimized for serverless, cloud, and Kubernetes environments.
+      In this quick start, you'll use the RHOAS CLI and RHOAS Operator to bind an example Quarkus application to a Kafka instance. [Quarkus](https://quarkus.io/) is a Kubernetes-native Java framework that is optimized for serverless, cloud, and Kubernetes environments.
 
-      When you use the RHOAS CLI to bind a Kafka instance with an application, the RHOAS Operator automatically injects connection credentials as files into the Pod for your application. The example Quarkus application uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding), which means that the application automatically detects and uses the injected connection credentials. This eliminates the need for manual configuration of your application.
+      When you use the RHOAS CLI to bind a Kafka instance with an application, the RHOAS Operator automatically injects connection parameters as files into the Pod for the application. The example Quarkus application in this quick start uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding), which means that the application automatically detects and uses the injected connection parameters. This eliminates the need for manual configuration of the application.
 
       #### Prerequisites
-      - You've completed the **Connecting an OpenShift project to Streams for Apache Kafka using the CLI** quick start.
-      - You have privileges to deploy applications in the OpenShift project to which you connected your Kafka instance.
-      - Your Kafka instance in Streams for Apache Kafka is in the **Ready** state.
+      - You've completed the **Connecting OpenShift to Streams for Apache Kafka using the CLI** quick start.
+      - You have privileges to deploy applications in the OpenShift project that you connected your Kafka instance to.
+      - Your Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/) is in the **Ready** state.
 
   tasks:
     - title: Deploying an example Quarkus application
       description: |-
 
-        In this task, you'll deploy an example Quarkus application.
+        In this task, you'll deploy an example Quarkus application in the same project that you previously connected your Kafka instance to.
 
         The Quarkus application generates random numbers between 0 and 100 and produces those numbers to a Kafka topic. Another part of the application consumes the numbers from the Kafka topic. Finally, the application uses *server-sent events* to expose the numbers as a REST UI. A web page in the application displays the exposed numbers.
 
         #### Prerequisites
-        - You've completed the **Connecting an OpenShift project to Streams for Apache Kafka using the CLI** quick start.
+        - You've completed the **Connecting an OpenShift project to Red Hat OpenShift Streams for Apache Kafka using the CLI** quick start.
         - You have privileges to deploy applications in the OpenShift project that you connected your Kafka instance to.
 
         #### Procedure
 
-        1. Log in to the OpenShift web console with privileges to deploy applications in the same project that you previously connected your Kafka instance to.
+        1. Log in to the OpenShift web console with privileges to deploy applications in the project that you previously connected your Kafka instance to.
 
         1. Click the [perspective switcher]{{highlight qs-perspective-switcher}}. Switch to the **Developer** perspective.
+           The **Topology** page opens.
 
-        1. Click the **Project** drop-down menu at the top of the page. Select the project that you connected your Kafka instance to.
+        1. Ensure that the current OpenShift project is the one you previously connected your Kafka instance to.
+
+            i. At the top of the **Topology** page, click the **Project** drop-down menu.
+
+            ii. Select the project that you previously connected your Kafka instance to.
 
         1. Deploy the example Quarkus application.
 
             i. Click [Add]{{highlight qs-nav-add}}.
 
-            ii. Click **Container images**.
+            ii. On the **Add** page, click **Container images**.
                 The **Deploy Image** page opens.
 
             iii. For the **Image name from external registry** option, enter `quay.io/rhoas/rhoas-quarkus-kafka-quickstart`.
@@ -61,8 +66,8 @@ spec:
             iv. For the **Runtime icon** option, select `quarkus`. For all other options, keep the default values.
 
             vi. Click **Create**.
-                  The [Topology]{{highlight qs-nav-topology}} page opens.
-                  You should see an icon for the Quarkus application you created. After some time, the icon should have a dark blue circle, which indicates that OpenShift deployed the application successfully.
+                  The **Topology** page opens.
+                  You should see an icon for the Quarkus application you created. After some time, the icon should have a dark blue circle. This indicates that OpenShift deployed the application successfully.
 
            vii. Click the **Open URL** link in the top-right corner of the icon for the application.
                   A web page for the Quarkus application opens.
@@ -70,20 +75,18 @@ spec:
         1. In your web browser, add `/prices.html` to the URL of the web page for the Quarkus application.
            A new web page, entitled **Last price**, opens. Because you have not yet connected the Quarkus application to your Kafka instance, the price value appears as `N/A`.
 
-        1. In the OpenShift web console, click [Topology]{{highlight qs-nav-topology}}.
-
-        1. Click the icon for the Quarkus application.
+        1. In the OpenShift web console, click the icon for the Quarkus application.
            A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should see a single Pod, corresponding to the Quarkus application.
 
-        1. Click the **View logs** link next to the name of the Pod.
+        1. Next to the name of the Pod, click **View logs**.
            In the logs for the Quarkus application, you see warnings indicating that the application can't connect to Kafka. You'll establish this connection in a later task.
 
       review:
         instructions: |-
           #### Verify that you successfully deployed the example Quarkus application
-          * Do you see a Quarkus application on the Topology page of your project?
-          * Does the Quarkus application icon have a dark blue circle around it, indicating a successful deployment?
-          * Do the logs for the Quarkus application Pod state that the application can't connect to a Kafka instance?
+          * Did you see the Quarkus application on the Topology page of your project?
+          * Did the Quarkus application icon have a dark blue circle around it, indicating a successful deployment?
+          * Did the logs for the Quarkus application Pod state that the application can't connect to a Kafka instance?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
         success: >-
@@ -96,7 +99,7 @@ spec:
         In the previous task, you created an example Quarkus application that uses a Kafka topic called `prices` to produce and consume messages. In this task, you'll create the `prices` topic in your Kafka instance.
 
         #### Prerequisites
-        - Your Kafka instance is in the **Ready** state.
+        - Your Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/) is in the **Ready** state.
 
         #### Procedure
 
@@ -118,7 +121,7 @@ spec:
       review:
         instructions: |-
           #### Verify that you successfully created the Kafka topic
-          Is the `prices` topic listed in the topics table?
+           - Is the `prices` topic listed in the topics table?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
         success: >-
@@ -128,32 +131,44 @@ spec:
     - title: Binding the Quarkus application to your Kafka instance
       description: |-
 
-        In this task, you use the RHOAS CLI to bind your Kafka instance to your example Quarkus application. When you perform this binding, the RHOAS Operator injects connection credentials as files into the Pod for the application.
+        In this task, you use the RHOAS CLI to bind your Kafka instance to the example Quarkus application you created. When you perform this binding, the RHOAS Operator injects connection parameters as files into the Pod for the application.
 
-        The Quarkus application in this quick start uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding). This means that the application automatically detects and uses the injected connection credentials.
+        The Quarkus application in this quick start uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding). This means that the application automatically detects and uses the injected connection parameters.
 
         #### Prerequisites
-        - You've completed the **Connecting an OpenShift project to Red Hat OpenShift Streams for Apache Kafka to the CLI** quick start.
+        - You've completed the **Connecting OpenShift to Red Hat OpenShift Streams for Apache Kafka using the CLI** quick start.
         - You've deployed the example Quarkus application.
-        - Your Kafka instance is in the **Ready** state.
+        - Your Kafka instance in [Streams for Apache Kafka](https://cloud.redhat.com/beta/application-services/streams/) is in the **Ready** state.
         - You've created the `prices` topic in your Kafka instance.
 
         #### Procedure
 
-        1. Ensure that you're logged into OpenShift as the same user that deployed the Quarkus application earlier in this quick start.
+        1. If you used an image provided by Red Hat to install CLI tools in your OpenShift project:
 
-        1. Open a terminal window. If you installed the CLI tools in your OpenShift project using an image provided by Red Hat:
+            i. Ensure that you're logged in to the OpenShift web console as the same user that deployed the Quarkus application in the previous task.
 
-            i. In your project, click the icon for the tools application.
-            A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should see a single Pod, corresponding to the tools application.
+            ii. In your project, click the icon for the tools application.
+                A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should see a single Pod, corresponding to the tools application.
 
-             ii. Click the link to the Pod.
+            iii. Click the link to the Pod.
                  The **Pod details** page opens.
 
-             iii. Click the **Terminal** tab.
-                  A terminal window opens inside the Pod.
+            iv. Click the **Terminal** tab.
+                A terminal window opens inside the Pod.
 
-        1. Ensure that the current OpenShift project is the one in which you deployed the example Quarkus application. For example:
+        1. If you deployed CLI tools locally on your machine:
+
+            i. Open a terminal window.
+
+            ii. Log in to OpenShift as the same user that deployed the Quarkus application in the previous task.
+
+           ```
+           $ oc login -u <user> -p <password> --server=<host:port>
+           ```
+
+           In the preceding example, replace the values in angle brackets (`< >`) with your own values.
+
+        1. In your terminal window, ensure that the current OpenShift project is the one in which you deployed the example Quarkus application. For example:
 
            ```
            $ oc project my-project
@@ -164,6 +179,8 @@ spec:
            ```
            $ rhoas cluster bind
            ```
+
+           You're prompted to specify the Kafka instance in Streams for Apache Kafka that you want to connect to OpenShift.
 
         1. Type the name of the Kafka instance that you want to connect to OpenShift. Press **Enter**.
 
@@ -176,48 +193,40 @@ spec:
            ```
            Binding my-kafka-instance with rhoas-quarkus-kafka-quickstart app succeeded
            ```
-           The preceding output shows that the RHOAS CLI has successfully bound a Kafka instance called `my-kafka-instance` to the example Quarkus application (called `rhoas-quarkus-kafka-quickstart`) in OpenShift.
+           The output shows that the RHOAS CLI successfully bound a Kafka instance called `my-kafka-instance` to the example Quarkus application (called `rhoas-quarkus-kafka-quickstart`).
 
-           When service binding is complete, OpenShift redeploys the Quarkus application. The Quarkus application starts to use the `prices` Kafka topic that you created. One part of the Quarkus application publishes price updates to this topic, while another part of the application consumes the updates.
+           OpenShift redeploys the Quarkus application. When the application is running, it starts using the `prices`topic that you created in your Kafka instance. One part of the Quarkus application publishes price updates to this topic, while another part of the application consumes the updates.
 
-        1. To verify that the Quarkus application is using the Kafka topic, reopen the **Last price** web page that you opened earlier in this quick start.
+        1. Reopen the **Last price** web page that you opened in the first task of this quick start.
 
-            i. In the OpenShift web console, click [Topology]{{highlight qs-nav-topology}}.
-               The icon for the Quarkus application should still include a dark blue circle, which indicates that OpenShift redeployed the application successfully.
-
-            ii. Click the **Open URL** link in the top-right corner of the icon for the Quarkus application.
-                The default web page for the Quarkus application opens.
-
-            iii. In your web browser, add `/prices.html` to the URL of the web page for the Quarkus application.
-                 The **Last price** web page opens.
-                 On the web page, observe that the the price value is continuously updated. The updates show that the Quarkus application is now using the `prices` topic in your Kafka instance to produce and consume messages.
+        1. On the **Last price** web page, observe that the the price value is continuously updated. The Quarkus application is now using the `prices` topic in your Kafka instance to produce and consume messages.
 
         1. In the OpenShift web console, click [Topology]{{highlight qs-nav-topology}}.
 
         1. Click the icon for the Quarkus application.
            A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should still see a Pod corresponding to the Quarkus application.
 
-        1. Click the **View logs** link next to the name of the Pod.
-           In the logs for the Quarkus application, you should see that the Quarkus application has now connected to a Kafka instance.
+        1. Next to the name of the Pod, click **View logs**.
+           You should now see that the Quarkus application has connected to a Kafka instance.
 
         1. On the same page of the console, click the **Details** tab. Scroll down until you see the **Volumes** section.
-           Observe that there is a volume mounted on the `/bindings` path of the Pod. This volume contains the files that the RHOAS Operator injected into the application. Each file contains a single connection credential for your Kafka instance, specified in plain text.
+           Observe that there is a volume mounted on the `/bindings` path of the Pod. This volume contains the files for individual connection parameters that the RHOAS Operator injected into the application.
 
-           Because the Quarkus application uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding), the application automatically detects and uses the injected connection credentials.
+           Because the Quarkus application uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding), the application automatically detects and uses the injected connection parameters.
 
       review:
         instructions: |-
           #### Verify that you successfully bound your Quarkus application to your Kakfa instance in OpenShift Streams for Apache Kafka
           - Is the price value continuously updated on the **Last price** web page of the Quarkus application?
-          - Do the logs in the Pod for the Quarkus application show that the application is connected to you Kafka instance?
-          - Do you see service binding files mounted on a volume in the Pod for the Quarkus application?
+          - Did the logs in the Pod for the Quarkus application show that the application is connected to a Kafka instance?
+          - Did you see service binding files mounted on a volume in the Pod for the Quarkus application?
 
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
         success: >-
-          Great work! You've bound an example Quarkus application to a Kafka instance in Streams for Apache Kafka.
+          Congratulations! You successfully bound an example Quarkus application running in OpenShift to a Kafka instance in Streams for Apache Kafka.
         failed: Try the steps again.
 
   conclusion: >-
-    You've successfully bound a Quarkus application running on OpenShift to your Kafka instance in Streams for Apache Kafka.
-    The RHOAS Operator automatically injected the connection credentials required for your Quarkus application to connect to your Kafka instance.
+    Congratulations! You successfully bound a Quarkus application running in OpenShift to a Kafka instance in Streams for Apache Kafka.
+    The RHOAS Operator automatically injected the connection parameters required for the Quarkus application to connect to the Kafka instance.

--- a/olm/quickstarts/rhosak-openshift-quarkus-bind-quickstart.yaml
+++ b/olm/quickstarts/rhosak-openshift-quarkus-bind-quickstart.yaml
@@ -3,223 +3,221 @@ kind: ConsoleQuickStart
 metadata:
   name: rhosak-devsandbox-quarkus-bind-cli-toolscontainer-quickstart
 spec:
-  displayName: Binding your Quarkus application to Streams for Apache Kafka
+  displayName: Binding a Quarkus application to Streams for Apache Kafka
   tags:
     - streams
     - kafka
     - quarkus
   durationMinutes: 10
-  description: Binding your Quarkus application to the OpenShift Streams for Apache Kafka cloud service
+  description: Binding a Quarkus application to a Kafka instance in Streams for Apache Kafka
   prerequisites:
-    - Access to Red Hat OpenShift Streams for Apache Kafka (for more information, visit https://cloud.redhat.com/application-services).
-    - A running OpenShift Streams for Apache Kafka instance.
-    - A connection (KafkaConnection) betweeen your OpenShift project and your OpenShift Streams for Apache Kafka instance.
-  introduction: >-
-    ### This quick start shows you how to bind your Quarkus application to your Red Hat OpenShift Streams for Apache Kafka instance.
+    - You've completed the **Connecting an OpenShift project to Streams for Apache Kafka using the CLI** quick start.
+    - You have privileges to deploy applications in the OpenShift project that you connected your Kafka instance to.
+    - Your Kafka instance in Streams for Apache Kafka is in the **Ready** state.
 
-    In this Quick Start, you'll bind a Quarkus application to your Kafka instance using Kubernetes Service Binding.
-    Service Binding allows you to communicate connection details and secrets to an application to allow it to bind to a service.
-    In this context, a service can be anything: a Kafka instance, a NoSQL database, etc.
+  introduction: |-
+      ### This quick start shows how to bind an example Quarkus application to a Kafka instance in Red Hat OpenShift Streams for Apache Kafka.
 
-    By using Service Binding, we no longer need to configure connection details (host, port) authentication mechanisms (SASL, OAuth) and
-    credentials (username/password, client id/client secret) in an application. Instead, Service Binding injects these variables into your
-    application container (as files or environment variables), for your application to consume.
+      As a developer of applications and services, there might be cases where you need to connect OpenShift applications to Kafka instances in Streams for Apache Kafka. Connecting an OpenShift application to a backing service such as Streams for Apache Kafka is called *service binding*.
 
-    The Quarkus Kubernetes Service Binding extension enables Quarkus applications to automatically pickup these variables, injected as files, from the container's
-    filesystem, removing the need to specify any configuration settings in the application resources (e.g configuration files) themselves.
+      In this quick start, you'll use the Red Hat OpenShift Application Services (RHOAS) Operator and CLI to bind an example Quarkus application to your Kafka instance. [Quarkus](https://quarkus.io/^) is a Kubernetes-native Java framework that is optimized for serverless, cloud, and Kubernetes environments.
+
+      When you use the RHOAS CLI to bind a Kafka instance with an application, the RHOAS Operator automatically injects connection credentials as files into the Pod for your application. The example Quarkus application uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding), which means that the application automatically detects and uses the injected connection credentials. This eliminates the need for manual configuration of your application.
+
+      #### Prerequisites
+      - You've completed the **Connecting an OpenShift project to Streams for Apache Kafka using the CLI** quick start.
+      - You have privileges to deploy applications in the OpenShift project to which you connected your Kafka instance.
+      - Your Kafka instance in Streams for Apache Kafka is in the **Ready** state.
+
   tasks:
-    - title: Deploying your Quarkus application
+    - title: Deploying an example Quarkus application
       description: |-
-        As the first task, you will deploy a Quarkus application that produces to, and consumes from, a Kafka instance.
-        It's an adapted version of the standard Quarkus Kafka Quick Start, as we've added the Quarkus Kubernetes Service Binding plugin.
 
-        The Quick Start is a PriceConverter application that generates random prices (integers) and sends them to a Kafka topic.
-        Another component of the application consumes these prices, applies a conversion and makes them available via a REST service endpoint.
-        The output can be inspected on a simple webpage.
+        In this task, you'll deploy an example Quarkus application.
 
-        To deploy the Quarkus application:
+        The Quarkus application generates random numbers between 0 and 100 and produces those numbers to a Kafka topic. Another part of the application consumes the numbers from the Kafka topic. Finally, the application uses *server-sent events* to expose the numbers as a REST UI. A web page in the application displays the exposed numbers.
 
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        #### Prerequisites
+        - You've completed the **Connecting an OpenShift project to Streams for Apache Kafka using the CLI** quick start.
+        - You have privileges to deploy applications in the OpenShift project that you connected your Kafka instance to.
 
-        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        #### Procedure
 
-        1. Make sure that your OpenShift **Project**, which you can see at the top of the **Add** window, is set to `{username}-dev` (where *{username}* is your username in the DevSandbox OpenShift environment). 
-        This should be the project in which you have created your ```KafkaConnection``` in the **Connecting Red Hat OpenShift Streams for Apache Kafka to OpenShift** Quick Start.
+        1. Log in to the OpenShift web console with privileges to deploy applications in the same project that you previously connected your Kafka instance to.
 
-        To reduce the wait time of this Quick Start, we have pre-built the container image with the Quarkus application, allowing us to directly deploy the container instead of having to build it.
-        The source code of this application can be found [here](https://github.com/redhat-developer/app-services-guides/tree/main/code-examples/quarkus-kafka-quickstart):
+        1. Click the [perspective switcher]{{highlight qs-perspective-switcher}}. Switch to the **Developer** perspective.
 
-        1. Click on the **Container Image** card.
+        1. Click the **Project** drop-down menu at the top of the page. Select the project that you connected your Kafka instance to.
 
-        1. In the **Image name from external registry** field, enter: `quay.io/rhoas/rhoas-quarkus-kafka-quickstart`
+        1. Deploy the example Quarkus application.
 
-        1. In the *Runtime icon** field, select `quarkus`.
+            i. Click [Add]{{highlight qs-nav-add}}.
 
-        1. Leave all the the fields set to their default values and click the **Create** button. This will create a new OpenShift **Deployment** for your Quarkus application.
+            ii. Click **Container images**.
+                The **Deploy Image** page opens.
 
-        1. You will see the deployment of your Quarkus application in the [Topology]{{highlight qs-perspective-topology}} screen. The icon of your Quarkus applications should have a blue circle around it, indicating that the application has been deployed successfully.
+            iii. For the **Image name from external registry** option, enter `quay.io/rhoas/rhoas-quarkus-kafka-quickstart`.
 
-        1. Click on the **Open URL** icon in the upper-right of your Quarkus application icon in the Topology view. You will see the default Quarkus page.
+            iv. For the **Runtime icon** option, select `quarkus`. For all other options, keep the default values.
 
-        1. Add the path `/prices.html` to the URL of your Quarkus application. This will open the **prices** page of your Quarkus application.
-        Since the application is not connected to Kafka yet, the page shows that prices are not available.
+            vi. Click **Create**.
+                  The [Topology]{{highlight qs-nav-topology}} page opens.
+                  You should see an icon for the Quarkus application you created. After some time, the icon should have a dark blue circle, which indicates that OpenShift deployed the application successfully.
 
-        1. Go back to your OpenShift Topology view and click on the icon of your Quarkus application. This will open a panel on the righ-hand-side of your screen.
-        Click on the **Resources** tab. You will see the **Pods** of your Deployment. Currently we only have a single pod.
+           vii. Click the **Open URL** link in the top-right corner of the icon for the application.
+                  A web page for the Quarkus application opens.
 
-        1. Click on the **View logs** link next to the pod. In the logs of your application, you will see warnings stating that the application can not connect to Kafka.
+        1. In your web browser, add `/prices.html` to the URL of the web page for the Quarkus application.
+           A new web page, entitled **Last price**, opens. Because you have not yet connected the Quarkus application to your Kafka instance, the price value appears as `N/A`.
+
+        1. In the OpenShift web console, click [Topology]{{highlight qs-nav-topology}}.
+
+        1. Click the icon for the Quarkus application.
+           A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should see a single Pod, corresponding to the Quarkus application.
+
+        1. Click the **View logs** link next to the name of the Pod.
+           In the logs for the Quarkus application, you see warnings indicating that the application can't connect to Kafka. You'll establish this connection in a later task.
 
       review:
         instructions: |-
-          #### Verify that you've deployed your Quarkus application:
-          Do you see a Quarkus application in your Topology view?
-
-          Does the Quarkus application icon have blue circle around it, indicating a successful deployment?
-
-          Did you inspect the logs of your application pod? Did you see the warnings stating that the application could not connect to a Kafka instance?
+          #### Verify that you successfully deployed the example Quarkus application
+          * Do you see a Quarkus application on the Topology page of your project?
+          * Does the Quarkus application icon have a dark blue circle around it, indicating a successful deployment?
+          * Do the logs for the Quarkus application Pod state that the application can't connect to a Kafka instance?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
         success: >-
-          Great work! You've deployed your Quarkus application to your OpenShift project/namespace.
+          You've successfully deployed an example Quarkus application to your OpenShift project.
         failed: Try the steps again.
 
     - title: Creating a Kafka topic for your Quarkus application
-      description: >-
-        Your Quarkus application is configured to produce to, and consume from a topic named ```prices```.
-        We therefore need to creat this topic in Streams for Apache Kafka.
+      description: |-
 
-        1. Navigate to the In the **Kafka Instances** page of the [Streams for Apache Kafka web console](https://cloud.redhat.com/beta/application-services/streams/kafkas). Click on the name of the Kafka instance that you want to add a topic to.
+        In the previous task, you created an example Quarkus application that uses a Kafka topic called `prices` to produce and consume messages. In this task, you'll create the `prices` topic in your Kafka instance.
 
-        1. Click **Create topic** and follow the guided steps to define the topic details. 
-        Click **Next** to complete each step and click **Finish** to complete the setup.
+        #### Prerequisites
+        - Your Kafka instance is in the **Ready** state.
+
+        #### Procedure
+
+        1. In your web browser, open the [Kafka Instances](https://cloud.redhat.com/beta/application-services/streams/kafkas) page of the Streams for Apache Kafka web console. Click the name of the Kafka instance that you want to add a topic to.
+
+        1. Click **Create topic** and follow the guided steps to define the topic details. Click **Next** to complete each step and click **Finish** to complete the setup.
+
+           Specify the following values:
 
             **Topic name**: ```prices```.
 
-            **Partitions**: ```1```
+            **Partitions**: ```1```.
 
-            **Message retention**: ```1 day```
-            
-            **Replicas**: Replicas configuration is by default configured as ```3 replicas``` and ```2 min in-sync-replicas```.
+            **Retention time**: ```1 day```
 
-        After you complete the topic setup, the new Kafka topic is listed in the topics table. 
-        Your Quarkus application can now start producing and consuming messages to and from this topic .
+            **Replicas**: By default, this option is preconfigured to `3` replicas and `2` minimum in-sync-replicas.
+
+        After you complete the topic setup, the new Kafka topic is listed in the topics table. You're now ready to bind the example Quarkus application to your Kafka instance, so that the application can use the topic to produce and consume messages.
       review:
         instructions: |-
-          Is the new Kafka topic listed in the topics table?
+          #### Verify that you successfully created the Kafka topic
+          Is the `prices` topic listed in the topics table?
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
         success: >-
-          You have completed this task!
+          You successfully created the topic needed by the example Quarkus application. You're now ready to bind the Quarkus application to your Kafka instance.
         failed: Try the steps again.
 
-    - title: Access the required (CLI) Tools.
+    - title: Binding the Quarkus application to your Kafka instance
       description: |-
-        To bind your Quarkus application to the Streams for Apache Kafka instance, you will use the ```oc``` command line tool. We've provided all the tools necessary to complete
-        this Quick Start in an image that you can deploy in your OpenShift project. Alternatively, you can install  OpenShift Client (oc) on your own machine. These tools can be downloaded from:
-          * oc: [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)
 
-        To install the tooling image, do the following (if you are using your local installation of the RHOAS CLI, or if you've alread installed the tooling image in a previous Quick Start, you can skip these steps):
+        In this task, you use the RHOAS CLI to bind your Kafka instance to your example Quarkus application. When you perform this binding, the RHOAS Operator injects connection credentials as files into the Pod for the application.
 
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        The Quarkus application in this quick start uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding). This means that the application automatically detects and uses the injected connection credentials.
 
-        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        #### Prerequisites
+        - You've completed the **Connecting an OpenShift project to Red Hat OpenShift Streams for Apache Kafka to the CLI** quick start.
+        - You've deployed the example Quarkus application.
+        - Your Kafka instance is in the **Ready** state.
+        - You've created the `prices` topic in your Kafka instance.
 
-        1. Make sure that your OpenShift **Project**, which you can see at the top of the **Add** window, is set to `{username}-dev` (where *{username}* is your username in the DevSandbox OpenShift environment).
+        #### Procedure
 
-        1. Click on the **Container Image** card.
+        1. Ensure that you're logged into OpenShift as the same user that deployed the Quarkus application earlier in this quick start.
 
-        1. In the **Image name from external registry** field, enter: `quay.io/rhosak/rhoas-tools`.
+        1. Open a terminal window. If you installed the CLI tools in your OpenShift project using an image provided by Red Hat:
 
-        1. In the *Runtime icon* field, select `openshift`.
+            i. In your project, click the icon for the tools application.
+            A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should see a single Pod, corresponding to the tools application.
 
-        1. Uncheck the **Route** box and leave all other fields set to their default values.
-        You don't need a route for this application, so under the **Advanced Options** you can uncheck the **create a route to the Application** checkbox. 
-        Click the **Create** button. This will create a new OpenShift **Deployment** for the tools image.
+             ii. Click the link to the Pod.
+                 The **Pod details** page opens.
 
-        Pulling the container image and creating the container will take a couple of seconds.
+             iii. Click the **Terminal** tab.
+                  A terminal window opens inside the Pod.
 
-        1. You will see the deployment of the tools image in the [Topology]{{highlight qs-nav-add}} screen. The icon of the application should have a blue circle around it, indicating that the application has been deployed successfully.
+        1. Ensure that the current OpenShift project is the one in which you deployed the example Quarkus application. For example:
 
-        1. Click on the icon of the tools application. This will open a panel on the righ-hand-side of your screen.
-        Click on the **Resources** tab. You will see the **Pods** of your Deployment. Currently we only have a single pod.
+           ```
+           $ oc project my-project
+           ```
 
-        1. Click on the link to the pod. This opens the details page of the pod.
+        1. Use the RHOAS CLI to bind your Kafka instance to your OpenShift project.
 
-        1. Open the **Terminal** tab. This opens a terminal inside the pod. To check whether you can access the required tooling, execute the command `oc` in your terminal.
-        This should print the OpenShift Client CLI help text.
+           ```
+           $ rhoas cluster bind
+           ```
 
-        You now need to connect `oc` to your OpenShift environment. If you've previously done this in another Quick Start, you might not need to do this again.
-        You can verify this by executing the `oc status` command. If that returns without errors, showing the current project and the OpenShift instance you're connected to, you can skip the following steps.
+        1. Type the name of the Kafka instance that you want to connect to OpenShift. Press **Enter**.
 
-        1. In your terminal, first login the **oc** client to our OpenShift instance. To do this:
-            1. Click on your username in the top-right of the OpenShift console and click **Copy login command**
-            1. A new tab opens in your browser with the OpenShift Developer Sandbox login screen. In the *Log in with...* box, select **DevSandbox**.
-            1. Click on **Display Token**.
-            1. Copy the `oc login` command.
-            1. Go to your terminal, and execute the command you just copied.
+           You're prompted to specify the OpenShift application that you want to bind your Kafka instance to.
 
-        With your `oc` client connected, point it to the correct project:
-        1. In your terminal, point your **oc** client to the correct OpenShift namespace/project (replace *{username}* with your username in the Developer Sandbox OpenShift environment): `oc project {username}-dev`. This should be the project in which you've deployed your Quarkus application and that contains the `KafkaConnection`.
-        1. Execute the command `oc get deployment`. This should returen the **Deployment** of you Quarkus application, and the **Deployment** of your tools container (if you're using that container).
+        1. To bind to the the example Quarkus application that you deployed, type `rhoas-quarkus-kafka-quickstart`. Press **Enter**.
+
+        1. Type `y` to confirm that you want to continue. Press **Enter**.
+           When binding is complete, you should see output like the following:
+           ```
+           Binding my-kafka-instance with rhoas-quarkus-kafka-quickstart app succeeded
+           ```
+           The preceding output shows that the RHOAS CLI has successfully bound a Kafka instance called `my-kafka-instance` to the example Quarkus application (called `rhoas-quarkus-kafka-quickstart`) in OpenShift.
+
+           When service binding is complete, OpenShift redeploys the Quarkus application. The Quarkus application starts to use the `prices` Kafka topic that you created. One part of the Quarkus application publishes price updates to this topic, while another part of the application consumes the updates.
+
+        1. To verify that the Quarkus application is using the Kafka topic, reopen the **Last price** web page that you opened earlier in this quick start.
+
+            i. In the OpenShift web console, click [Topology]{{highlight qs-nav-topology}}.
+               The icon for the Quarkus application should still include a dark blue circle, which indicates that OpenShift redeployed the application successfully.
+
+            ii. Click the **Open URL** link in the top-right corner of the icon for the Quarkus application.
+                The default web page for the Quarkus application opens.
+
+            iii. In your web browser, add `/prices.html` to the URL of the web page for the Quarkus application.
+                 The **Last price** web page opens.
+                 On the web page, observe that the the price value is continuously updated. The updates show that the Quarkus application is now using the `prices` topic in your Kafka instance to produce and consume messages.
+
+        1. In the OpenShift web console, click [Topology]{{highlight qs-nav-topology}}.
+
+        1. Click the icon for the Quarkus application.
+           A sidebar opens, with the **Resources** tab displayed. Under **Pods**, you should still see a Pod corresponding to the Quarkus application.
+
+        1. Click the **View logs** link next to the name of the Pod.
+           In the logs for the Quarkus application, you should see that the Quarkus application has now connected to a Kafka instance.
+
+        1. On the same page of the console, click the **Details** tab. Scroll down until you see the **Volumes** section.
+           Observe that there is a volume mounted on the `/bindings` path of the Pod. This volume contains the files that the RHOAS Operator injected into the application. Each file contains a single connection credential for your Kafka instance, specified in plain text.
+
+           Because the Quarkus application uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding), the application automatically detects and uses the injected connection credentials.
 
       review:
         instructions: |-
-          #### Verify that you've successfully connected your `oc` client to your OpenShift instance:
-          Did you see the **Deployment** of your Quarkus application as output of the `oc get deployment` command?
+          #### Verify that you successfully bound your Quarkus application to your Kakfa instance in OpenShift Streams for Apache Kafka
+          - Is the price value continuously updated on the **Last price** web page of the Quarkus application?
+          - Do the logs in the Pod for the Quarkus application show that the application is connected to you Kafka instance?
+          - Do you see service binding files mounted on a volume in the Pod for the Quarkus application?
+
         failedTaskHelp: This task isn’t verified yet. Try the task again.
       summary:
         success: >-
-          Great work! You have access to the tooling required for the remainder of this quickstart.
-        failed: Try the steps again.
-    - title: Bind your Quarkus application to your Streams for Apache Kafka instance.
-      description: |-
-        With your Quarkus application running, and your Streams for Apache Kafka instance connected to your namespace, you can now bind your application to your Kafka instance.
-        This is done using the Service Binding Operator, which will inject the configuration values required to connect to your Kafka instance into your Quarkus application.
-        The Quarkus application has been configured to use the `quarkus-kubernetes-service-binding` [extension](https://github.com/DuncanDoyle/quarkus-kafka-quickstart-summit2021/blob/main/pom.xml#L82-L85)
-        enabling auto-discovery of the binding files injected into the Quarkus application pod.
-
-        We will create the binding using the `rhoas` command line tool. In future versions of OpenShift, you will also be able to do this directly from the OpenShift Developer Console.
-
-        To create the binding, we simply use the `rhoas cluster bind` command, and select the application deployment that we want to bind to our Streams for Apache Kafka instance that has already been connected to our OpenShift project.
-
-        1. Go to the terminal of your tools container (or your own terminal if are using the tooling from your own machine).
-
-        1. Execute the command `rhoas cluster bind`:
-            1. Select the Kafka instance you want your application to connect with (if not already pre-selected).
-            1. Select `rhoas-quarkus-kafka-quickstart` as the application that you want to connect to your Kafka instance.
-            1. When asked if you want to continue, select `y` and press **Enter**.
-
-        1. The binding will mount the Kafka connection configuration as files into the Quarkus application pod, from where they will be automatically picked up by the `quarkus-kubernetes-service-binding` extension.
-
-        1. With the binding created, your Quarkus application will now redeploy. Go back to the **Topology** screen by clicking on the [Topology]{{highlight qs-nav-add}} in the navigation menu.
-
-        1. Click on the **Open URL** icon in the upper-right of your Quarkus application icon in the Topology view. You will see the default Quarkus page.
-
-        1. Add the path `/prices.html` to the URL of your Quarkus application. This will open the **prices** page of your Quarkus application.
-        The application has now been properly configured, and prices are being sent to and consumed from the Kafka topic.
-
-        1. Go back to the **Topology** screen, click on the Quarkus application. This will open a panel on the righ-hand-side of your screen.
-        Click on the **Resources** tab. You will see the **Pod** of your Deployment. Click on the **View logs** link next to your pod.
-        In the logs of your application, you will see that your Quarkus application has connected to Kafka.
-
-        1. In the same screen, click on the **Details** tab. Scroll down until you see the **Volumes** section. Note that there is a **kafka-binding** volume,
-        which contains the binding files that contain the information required by your Quarkus application to connect to your Kafka instance.
-        These files are auto-discovered and used by the **quarkus-kubernetes-service-binding** extension to automatically connect your Quarkus application to OpenShift Streams for Apache Kafka.
-
-      review:
-        instructions: |-
-          #### Verify that you've successfully connected your Quarkus application to your OpenShift Streams for Apache Kafka instance:
-          Did you see the **prices** in your Quarkus application's webpage?
-
-          Did you see the binding files mounted in your Quarkus application's pod?
-
-          Did you see your Quarkus application's logs? Did you see it being connected to your Kafka instance?
-        failedTaskHelp: This task isn’t verified yet. Try the task again.
-      summary:
-        success: >-
-          Great work! You've connected your Quarkus application to your Streams for Apache Kafka instance using Kubernetes Service Binding.
+          Great work! You've bound an example Quarkus application to a Kafka instance in Streams for Apache Kafka.
         failed: Try the steps again.
 
   conclusion: >-
-    You've successfully connected your Quarkus application running on OpenShift to your OpenShift Streams for Apache Kafka instance.
-    You've used Kubernetes Service Binding to automatically inject the configuration parameters to connect to your Kafka instance into your Quarkus application.
+    You've successfully bound a Quarkus application running on OpenShift to your Kafka instance in Streams for Apache Kafka.
+    The RHOAS Operator automatically injected the connection credentials required for your Quarkus application to connect to your Kafka instance.

--- a/olm/quickstarts/rhosak-openshift-quarkus-bind-quickstart.yaml
+++ b/olm/quickstarts/rhosak-openshift-quarkus-bind-quickstart.yaml
@@ -3,24 +3,24 @@ kind: ConsoleQuickStart
 metadata:
   name: rhosak-devsandbox-quarkus-bind-cli-toolscontainer-quickstart
 spec:
-  displayName: Binding a Quarkus application to Streams for Apache Kafka
+  displayName: Binding a Quarkus application to Streams for Apache Kafka using the CLI
   tags:
     - streams
     - kafka
     - quarkus
   durationMinutes: 10
-  description: Binding a Quarkus application to a Kafka instance in Streams for Apache Kafka
+  description: Binding a Quarkus application to Streams for Apache Kafka using the CLI
   prerequisites:
     - You've completed the **Connecting an OpenShift project to Streams for Apache Kafka using the CLI** quick start.
     - You have privileges to deploy applications in the OpenShift project that you connected your Kafka instance to.
     - Your Kafka instance in Streams for Apache Kafka is in the **Ready** state.
 
   introduction: |-
-      ### This quick start shows how to bind an example Quarkus application to a Kafka instance in Red Hat OpenShift Streams for Apache Kafka.
+      ### This quick start shows how to use Red Hat OpenShift Application Services (RHOAS) CLI to the bind an example Quarkus application to a Kafka instance in Red Hat OpenShift Streams for Apache Kafka.
 
       As a developer of applications and services, there might be cases where you need to connect OpenShift applications to Kafka instances in Streams for Apache Kafka. Connecting an OpenShift application to a backing service such as Streams for Apache Kafka is called *service binding*.
 
-      In this quick start, you'll use the Red Hat OpenShift Application Services (RHOAS) Operator and CLI to bind an example Quarkus application to your Kafka instance. [Quarkus](https://quarkus.io/^) is a Kubernetes-native Java framework that is optimized for serverless, cloud, and Kubernetes environments.
+      In this quick start, you'll use the RHOAS CLI and Operator to bind an example Quarkus application to your Kafka instance. [Quarkus](https://quarkus.io/^) is a Kubernetes-native Java framework that is optimized for serverless, cloud, and Kubernetes environments.
 
       When you use the RHOAS CLI to bind a Kafka instance with an application, the RHOAS Operator automatically injects connection credentials as files into the Pod for your application. The example Quarkus application uses the `quarkus-kubernetes-service-binding` [extension](https://quarkus.io/guides/deploying-to-kubernetes#service-binding), which means that the application automatically detects and uses the injected connection credentials. This eliminates the need for manual configuration of your application.
 


### PR DESCRIPTION
Refine the following YAML files for delivery as quick starts in OpenShift:

- [Connecting OpenShift to Streams for Apache Kafka using the CLI ](https://github.com/redhat-developer/app-services-operator/blob/main/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml)
- [Binding a Quarkus application to Streams for Apache Kafka using the CLI](https://github.com/redhat-developer/app-services-operator/blob/main/olm/quickstarts/rhosak-openshift-quarkus-bind-quickstart.yaml)