### PR TITLE
feat: quickstarts automatically installed

### DIFF
--- a/olm/olm-template/manifests/rhoas-operator.clusterserviceversion.yaml
+++ b/olm/olm-template/manifests/rhoas-operator.clusterserviceversion.yaml
@@ -90,6 +90,20 @@ spec:
             - patch
             - update
             - watch
+        - apiGroups:
+            - console.openshift.io
+          resources:
+            - 'consolequickstarts'
+            - 'consolequickstarts/status'
+            - 'consolequickstarts/finalizers'
+          verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
       deployments:
       - name: rhoas-operator
         spec:

--- a/olm/quickstarts/README.md
+++ b/olm/quickstarts/README.md
@@ -4,7 +4,7 @@ Quickstarts available as part of this operator.
 
 ## Adding Quick Starts to your OpenShift for local testing
 
-Add all Quick Starts to your OpenShift cluster
+The operator automatically installs quickstarts when it starts up. If you wish to replace them, you may use the following : 
 ```
 oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-operator/quickstarts/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
 oc apply -f https://raw.githubusercontent.com/redhat-developer/app-services-operator/quickstarts/olm/quickstarts/rhosak-openshift-getting-started-quickstart.yaml

--- a/source/rhoas/.gitignore
+++ b/source/rhoas/.gitignore
@@ -2,3 +2,4 @@ target
 .settings
 .factorypath
 .project
+src/main/resources/olm/quickstarts/*

--- a/source/rhoas/pom.xml
+++ b/source/rhoas/pom.xml
@@ -92,6 +92,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>copy-file</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes/olm/quickstarts</outputDirectory>
+              <resources>          
+                <resource>
+                  <directory>${project.parent.basedir}/olm/quickstarts/</directory>
+                </resource>
+              </resources>              
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
@@ -1,5 +1,6 @@
 package com.openshift.cloud;
 
+import com.openshift.cloud.beans.KafkaK8sClients;
 import com.openshift.cloud.controllers.CloudServiceAccountRequestController;
 import com.openshift.cloud.controllers.CloudServicesRequestController;
 import com.openshift.cloud.controllers.KafkaConnectionController;
@@ -31,6 +32,9 @@ public class RHOASOperator implements QuarkusApplication {
   @Inject
   CloudServiceAccountRequestController serviceAccountRequestController;
 
+  @Inject
+  KafkaK8sClients client;
+
   @ConfigProperty(name = "rhoas.client.apiBasePath")
   String clientBasePath;
 
@@ -43,6 +47,9 @@ public class RHOASOperator implements QuarkusApplication {
 
   @Override
   public int run(String... args) throws Exception {
+
+    client.initQuickStarts();
+
     LOG.info("Using API URL: " + clientBasePath);
 
     ControllerConfiguration<?> config = configuration.getConfigurationFor(connectionController);


### PR DESCRIPTION
This PR adds a feature to the operator that installs the quickstarts if they are not available on the system.

 == Verifying
Install the following catalog source into your cluster
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoas-operators2
  namespace: openshift-marketplace
spec:
  displayName: RHOAS Operators
  icon:
    base64data: ""
    mediatype: ""
  image: quay.io/secondsun/service-operator-registry:autolatest
  priority: -400
  publisher: RHOAS
  sourceType: grpc
  updateStrategy:
    registryPoll:
      interval: 260s

```

use the openshift admin console to install the operator from this source. (check for version 0.9.7 to differentiate it between the production operator).

Once the operator is installed you should see the quickstarts in lists of quickstarts (the develop landing page for instance) or with `oc get consolequickstarts --all-namespaces`

== Screen shot

![image](https://user-images.githubusercontent.com/2413816/123660107-5ce4d680-d801-11eb-9cb7-fcc31baeef3b.png)

