### PR TITLE
fix: using new operatorhub repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,6 @@ postgresql-operator
 .project
 .settings
 .vscode
-community-operators
+community-operators-prod
 *.iml
  

--- a/olm/operatorhub.sh
+++ b/olm/operatorhub.sh
@@ -1,13 +1,13 @@
 ## Script for manual release to operator hub
 ## After script finishes please manually 
 
-# git clone git@github.com:operator-framework/community-operators.git
+ git clone git@github.com:redhat-openshift-ecosystem/community-operators-prod.git
 VERSION=`cat version`
-mkdir ./community-operators/community-operators/rhoas-operator/${VERSION}
-cp -Rf ./olm-catalog/rhoas-operator/${VERSION}/manifests ./community-operators/community-operators/rhoas-operator/${VERSION}
-cp -Rf ./olm-catalog/rhoas-operator/${VERSION}/metadata ./community-operators/community-operators/rhoas-operator/${VERSION}
+mkdir ./community-operators-prod/operators/rhoas-operator/${VERSION}
+cp -Rf ./olm-catalog/rhoas-operator/${VERSION}/manifests ./community-operators-prod/operators/rhoas-operator/${VERSION}
+cp -Rf ./olm-catalog/rhoas-operator/${VERSION}/metadata ./community-operators-prod/operators/rhoas-operator/${VERSION}
 
-cd ./community-operators && \
+cd ./community-operators-prod && \
     git checkout -b rhoas-operator-${VERSION}  && \
     git add --all && \
     git commit --signoff -m"chore: update rhoas operator ${VERSION}"


### PR DESCRIPTION
OperatorHub moved their repos for the catalog, this PR updates the release scripts to point to the new community-operators-prod repository : https://github.com/redhat-openshift-ecosystem/community-operators-prod/