### PR TITLE
docs: add step to assign acl permissions to service account

### DIFF
--- a/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
+++ b/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
@@ -323,7 +323,7 @@ spec:
            NAME   		         AGE
            my-kafka-instance     2m35s
            ```
-           As shown in the output, the RHOAS Operator creates a `KafkaConnection` custom resource object that matches the name of your Kafka instance. In this example, the name matches a Kafka instance called `my-kafka-instance`.
+           As shown in the output, the RHOAS Operator creates a `KafkaConnection` custom resource object that matches the name of your Kafka instance. In this example, the name of the `KafkaConnection` object matches a Kafka instance called `my-kafka-instance`.
 
       review:
         instructions: |-


### PR DESCRIPTION
Notes for reviewers:

- These updates mirror the ones made to the service binding guide in https://github.com/redhat-developer/app-services-guides/pull/355.
- @DuncanDoyle plans to update the [tools image](https://quay.io/repository/rhosak/rhoas-tools) used in this quick start to run the latest version of the RHOAS CLI.