### PR TITLE
fix: removing automatic finalizer creation

### DIFF
--- a/source/rhoas/pom.xml
+++ b/source/rhoas/pom.xml
@@ -14,7 +14,7 @@
   <description>rhoas-operator</description>
   <properties>
     <fabric8.version>5.8.0</fabric8.version>
-    <quarkus.operator.sdk.version>2.0.0.CR2</quarkus.operator.sdk.version>
+    <quarkus.operator.sdk.version>2.0.0</quarkus.operator.sdk.version>
   </properties>
   <dependencies>
     <dependency>

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
@@ -12,7 +12,7 @@ import javax.inject.Inject;
 import java.time.Instant;
 
 /** Controller for CloudServiceAccountRequest CRs */
-@Controller
+@Controller(finalizerName = Controller.NO_FINALIZER)
 public class CloudServiceAccountRequestController
     extends AbstractCloudServicesController<CloudServiceAccountRequest> {
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServicesRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServicesRequestController.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
-@Controller
+@Controller(finalizerName = Controller.NO_FINALIZER)
 public class CloudServicesRequestController
     extends AbstractCloudServicesController<CloudServicesRequest> {
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/KafkaConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/KafkaConnectionController.java
@@ -13,7 +13,7 @@ import javax.inject.Inject;
 import java.time.Instant;
 import java.util.logging.Logger;
 
-@Controller
+@Controller(finalizerName = Controller.NO_FINALIZER)
 public class KafkaConnectionController extends AbstractCloudServicesController<KafkaConnection> {
 
   private static final Logger LOG = Logger.getLogger(KafkaConnectionController.class.getName());

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
@@ -6,11 +6,14 @@ import com.openshift.cloud.utils.ConnectionResourcesMetadata;
 import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.ServiceRegistryConnection;
 import io.javaoperatorsdk.operator.api.Context;
+import io.javaoperatorsdk.operator.api.Controller;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.inject.Inject;
 import java.time.Instant;
 
+@Controller(finalizerName = Controller.NO_FINALIZER)
 public class ServiceRegistryConnectionController
     extends AbstractCloudServicesController<ServiceRegistryConnection> {
 


### PR DESCRIPTION
Because we don't do anything special on delete, we can not include finalizers for now. This should make mass deletions of resources (ex during a namespace delete) faster and more reliable.