### PR TITLE
docs: add debugging with kubernetes instructions

### DIFF
--- a/build_docs/kubernetes-support.adoc
+++ b/build_docs/kubernetes-support.adoc
@@ -1,0 +1,19 @@
+== Kubernetes support
+
+=== Manually installing CRDS
+
+For rapid testing of RHOAS CLI we can use Operator CRDs in headles mode (without running controller).
+
+----
+minikube start
+cd olm/olm-catalog/rhoas-operator/0.9.0/manifests 
+kubectl apply -f .
+----
+
+=== Testing with running operator
+
+Operator can be started to process all requests created by RHOAS CLI
+
+----
+mvn quarkus:dev -Dkubernetes.trust.certificates=true
+----


### PR DESCRIPTION
This minimizes friction for running things on kubernetes. 
I think that feature in our operator that does create CRDs never worked (did not worked for the OpenShift either).
Manually creating CRDS makes all work fine. Instruction is mostly dedicated for rapid testing and bugfixing of rhoas cli cluster commands. 

 