### PR TITLE
fix: changing srs service bindings to use only token endpoint

### DIFF
--- a/olm/olm-template/manifests/rhoas-operator.serviceregistryconnections.crd.yaml
+++ b/olm/olm-template/manifests/rhoas-operator.serviceregistryconnections.crd.yaml
@@ -11,9 +11,7 @@ metadata:
            path={.status.serviceAccountSecretName},objectType=Secret,sourceKey=client-id
     service.binding/clientSecret: >-
       path={.status.serviceAccountSecretName},objectType=Secret,sourceKey=client-secret
-    service.binding/oauthTokenUrl: 'path={.status.metadata.oauthTokenUrl}'  
-    service.binding/oauthRealm: 'path={.status.metadata.oauthRealm}'
-    service.binding/oauthServerUrl: 'path={.status.metadata.oauthServerUrl}'
+    service.binding/oauthTokenUrl: 'path={.status.metadata.oauthTokenUrl}'
 spec:
   group: rhoas.redhat.com
   names:

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
@@ -31,10 +31,6 @@ public class ServiceRegistryConnectionController
   String oAuthRealm;
 
 
-  @ConfigProperty(name = "rhoas.client.srsOAuthTokenPath",
-      defaultValue = "protocol/openid-connect/token")
-  String oAuthTokenPath;
-
   @Override
   void doCreateOrUpdateResource(ServiceRegistryConnection resource,
       Context<ServiceRegistryConnection> context) throws Throwable {
@@ -56,7 +52,7 @@ public class ServiceRegistryConnectionController
     status.setRegistryUrl(registry.getRegistryUrl() + "/apis/registry/v2");
     status.setServiceAccountSecretName(serviceAccountSecretName);
     status.setMetadata(
-        ConnectionResourcesMetadata.buildServiceMetadata(oAuthHost, oAuthRealm, oAuthTokenPath));
+        ConnectionResourcesMetadata.buildServiceMetadata(oAuthHost, oAuthRealm));
 
   }
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
@@ -51,8 +51,7 @@ public class ServiceRegistryConnectionController
     status.setUpdated(Instant.now().toString());
     status.setRegistryUrl(registry.getRegistryUrl() + "/apis/registry/v2");
     status.setServiceAccountSecretName(serviceAccountSecretName);
-    status.setMetadata(
-        ConnectionResourcesMetadata.buildServiceMetadata(oAuthHost, oAuthRealm));
+    status.setMetadata(ConnectionResourcesMetadata.buildServiceMetadata(oAuthHost, oAuthRealm));
 
   }
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/utils/ConnectionResourcesMetadata.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/utils/ConnectionResourcesMetadata.java
@@ -9,6 +9,7 @@ public class ConnectionResourcesMetadata {
   private static final String UI_REF_TEMPLATE =
       "https://console.redhat.com/beta/application-services/streams/kafkas/%s";
 
+  private static final String SRS_OAUTH_TEMPLATE = "%s/realms/%s/protocol/openid-connect/token";
 
   /**
    * Contains hardcoded values for all metadata for Kafka specific properties
@@ -26,13 +27,10 @@ public class ConnectionResourcesMetadata {
     return map;
   }
 
-  public static Map<String, String> buildServiceMetadata(String oauthHost, String oauthRealm,
-      String tokenPath) {
+  public static Map<String, String> buildServiceMetadata(String oauthHost, String oauthRealm) {
     var map = new HashMap<String, String>();
     map.put("provider", "rhoas");
-    map.put("oauthServerUrl", oauthHost);
-    map.put("oauthRealm", oauthRealm);
-    map.put("oauthTokenUrl", oauthHost + "/" + tokenPath);
+    map.put("oauthTokenUrl", String.format(SRS_OAUTH_TEMPLATE, oauthHost, oauthRealm));
     map.put("type", "serviceregistry");
     return map;
   }


### PR DESCRIPTION
This changes the bindings exposed to only expose the token endpoint instead of server + realm. See : https://github.com/quarkusio/quarkus/pull/21618