### PR TITLE
fix: delete unused finalizers and cleanup deleted resources

### DIFF
--- a/source/model/src/main/java/com/openshift/cloud/v1alpha/models/ServiceRegistryConnectionList.java
+++ b/source/model/src/main/java/com/openshift/cloud/v1alpha/models/ServiceRegistryConnectionList.java
@@ -1,0 +1,6 @@
+package com.openshift.cloud.v1alpha.models;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class ServiceRegistryConnectionList extends CustomResourceList<ServiceRegistryConnection> {
+}

--- a/source/rhoas/pom.xml
+++ b/source/rhoas/pom.xml
@@ -14,7 +14,7 @@
   <description>rhoas-operator</description>
   <properties>
     <fabric8.version>5.8.0</fabric8.version>
-    <quarkus.operator.sdk.version>2.0.0</quarkus.operator.sdk.version>
+    <quarkus.operator.sdk.version>2.0.1</quarkus.operator.sdk.version>
   </properties>
   <dependencies>
     <dependency>

--- a/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
@@ -81,28 +81,32 @@ public class RHOASOperator implements QuarkusApplication {
 
   private void cleanupDeletedLegacyFinalizers() {
 
-    //Clean up legacy Finalizers for deleted resources
-    //We removed finalizers for several types, but didn't correctly remove them from instanced resources in k8s
-    //if those resources were deleted then we need to remove the finalizers here outside of the normal reconsiliation loop
+    // Clean up legacy Finalizers for deleted resources
+    // We removed finalizers for several types, but didn't correctly remove them from instanced
+    // resources in k8s
+    // if those resources were deleted then we need to remove the finalizers here outside of the
+    // normal reconsiliation loop
     var srcs = new ArrayList<>(client.serviceRegistryConnection().list().getItems());
     srcs.removeIf(item -> !item.isMarkedForDeletion());
-    srcs.forEach(src->src.removeFinalizer("serviceregistryconnections.rhoas.redhat.com/finalizer"));
-    srcs.forEach(src->client.serviceRegistryConnection().createOrReplace(src));
+    srcs.forEach(
+        src -> src.removeFinalizer("serviceregistryconnections.rhoas.redhat.com/finalizer"));
+    srcs.forEach(src -> client.serviceRegistryConnection().createOrReplace(src));
 
-    var csrs  = new ArrayList<>(client.cloudServicesRequest().list().getItems());
+    var csrs = new ArrayList<>(client.cloudServicesRequest().list().getItems());
     csrs.removeIf(item -> !item.isMarkedForDeletion());
-    csrs.forEach(csr->csr.removeFinalizer("cloudservicesrequests.rhoas.redhat.com/finalizer"));
-    csrs.forEach(csr->client.cloudServicesRequest().createOrReplace(csr));
+    csrs.forEach(csr -> csr.removeFinalizer("cloudservicesrequests.rhoas.redhat.com/finalizer"));
+    csrs.forEach(csr -> client.cloudServicesRequest().createOrReplace(csr));
 
     var akcs = new ArrayList<>(client.kafkaConnection().list().getItems());
     akcs.removeIf(item -> !item.isMarkedForDeletion());
-    akcs.forEach(akc->akc.removeFinalizer("kafkaconnections.rhoas.redhat.com/finalizer"));
-    akcs.forEach(akc->client.kafkaConnection().createOrReplace(akc));
+    akcs.forEach(akc -> akc.removeFinalizer("kafkaconnections.rhoas.redhat.com/finalizer"));
+    akcs.forEach(akc -> client.kafkaConnection().createOrReplace(akc));
 
     var csars = new ArrayList<>(client.cloudServiceAccountRequest().list().getItems());
     csars.removeIf(item -> !item.isMarkedForDeletion());
-    csars.forEach(csar->csar.removeFinalizer("cloudserviceaccountrequests.rhoas.redhat.com/finalizer"));
-    csars.forEach(csar->client.cloudServiceAccountRequest().createOrReplace(csar));
+    csars.forEach(
+        csar -> csar.removeFinalizer("cloudserviceaccountrequests.rhoas.redhat.com/finalizer"));
+    csars.forEach(csar -> client.cloudServiceAccountRequest().createOrReplace(csar));
 
 
   }

--- a/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
@@ -14,6 +14,8 @@ import io.quarkus.runtime.annotations.QuarkusMain;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
+import java.util.ArrayList;
+
 import javax.inject.Inject;
 
 @QuarkusMain
@@ -69,9 +71,39 @@ public class RHOASOperator implements QuarkusApplication {
     config = configuration.getConfigurationFor(serviceRegistryConnectionController);
     LOG.info("CR class: " + config.getCustomResourceClass());
 
+    cleanupDeletedLegacyFinalizers();
+
     operator.start();
 
     Quarkus.waitForExit();
     return 0;
+  }
+
+  private void cleanupDeletedLegacyFinalizers() {
+
+    //Clean up legacy Finalizers for deleted resources
+    //We removed finalizers for several types, but didn't correctly remove them from instanced resources in k8s
+    //if those resources were deleted then we need to remove the finalizers here outside of the normal reconsiliation loop
+    var srcs = new ArrayList<>(client.serviceRegistryConnection().list().getItems());
+    srcs.removeIf(item -> !item.isMarkedForDeletion());
+    srcs.forEach(src->src.removeFinalizer("serviceregistryconnections.rhoas.redhat.com/finalizer"));
+    srcs.forEach(src->client.serviceRegistryConnection().createOrReplace(src));
+
+    var csrs  = new ArrayList<>(client.cloudServicesRequest().list().getItems());
+    csrs.removeIf(item -> !item.isMarkedForDeletion());
+    csrs.forEach(csr->csr.removeFinalizer("cloudservicesrequests.rhoas.redhat.com/finalizer"));
+    csrs.forEach(csr->client.cloudServicesRequest().createOrReplace(csr));
+
+    var akcs = new ArrayList<>(client.kafkaConnection().list().getItems());
+    akcs.removeIf(item -> !item.isMarkedForDeletion());
+    akcs.forEach(akc->akc.removeFinalizer("kafkaconnections.rhoas.redhat.com/finalizer"));
+    akcs.forEach(akc->client.kafkaConnection().createOrReplace(akc));
+
+    var csars = new ArrayList<>(client.cloudServiceAccountRequest().list().getItems());
+    csars.removeIf(item -> !item.isMarkedForDeletion());
+    csars.forEach(csar->csar.removeFinalizer("cloudserviceaccountrequests.rhoas.redhat.com/finalizer"));
+    csars.forEach(csar->client.cloudServiceAccountRequest().createOrReplace(csar));
+
+
   }
 }

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaK8sClients.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaK8sClients.java
@@ -121,13 +121,14 @@ public final class KafkaK8sClients {
     KubernetesDeserializer.registerCustomKind(getApiVersion(CloudServiceAccountRequest.class),
         csarCrd.getKind(), CloudServiceAccountRequest.class);
 
-        return client.resources(CloudServiceAccountRequest.class, CloudServiceAccountRequestList.class);
+    return client.resources(CloudServiceAccountRequest.class, CloudServiceAccountRequestList.class);
   }
+
   public MixedOperation<ServiceRegistryConnection, ServiceRegistryConnectionList, Resource<ServiceRegistryConnection>> serviceRegistryConnection() {
     KubernetesDeserializer.registerCustomKind(getApiVersion(ServiceRegistryConnection.class),
         srcCrd.getKind(), ServiceRegistryConnection.class);
 
-        return client.resources(ServiceRegistryConnection.class, ServiceRegistryConnectionList.class);
+    return client.resources(ServiceRegistryConnection.class, ServiceRegistryConnectionList.class);
   }
 
   private CustomResourceDefinition initCloudServiceAccountRequestCRDAndClient(

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaK8sClients.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaK8sClients.java
@@ -105,32 +105,29 @@ public final class KafkaK8sClients {
     KubernetesDeserializer.registerCustomKind(getApiVersion(KafkaConnection.class),
         akcCrd.getKind(), KafkaConnection.class);
 
-    var akcCrdContext = CustomResourceDefinitionContext.fromCrd(this.akcCrd);
-
     // lets create a client for the CRD
-    return client.customResources(akcCrdContext, KafkaConnection.class, KafkaConnectionList.class);
+    return client.resources(KafkaConnection.class, KafkaConnectionList.class);
   }
 
   public MixedOperation<CloudServicesRequest, CloudServicesRequestList, Resource<CloudServicesRequest>> cloudServicesRequest() {
     KubernetesDeserializer.registerCustomKind(getApiVersion(CloudServicesRequest.class),
         cscrCrd.getKind(), CloudServicesRequest.class);
 
-    var akcCrdContext = CustomResourceDefinitionContext.fromCrd(this.cscrCrd);
-
     // lets create a client for the CRD
-    return client.customResources(akcCrdContext, CloudServicesRequest.class,
-        CloudServicesRequestList.class);
+    return client.resources(CloudServicesRequest.class, CloudServicesRequestList.class);
   }
 
   public MixedOperation<CloudServiceAccountRequest, CloudServiceAccountRequestList, Resource<CloudServiceAccountRequest>> cloudServiceAccountRequest() {
     KubernetesDeserializer.registerCustomKind(getApiVersion(CloudServiceAccountRequest.class),
         csarCrd.getKind(), CloudServiceAccountRequest.class);
 
-    var akcCrdContext = CustomResourceDefinitionContext.fromCrd(this.csarCrd);
+        return client.resources(CloudServiceAccountRequest.class, CloudServiceAccountRequestList.class);
+  }
+  public MixedOperation<ServiceRegistryConnection, ServiceRegistryConnectionList, Resource<ServiceRegistryConnection>> serviceRegistryConnection() {
+    KubernetesDeserializer.registerCustomKind(getApiVersion(ServiceRegistryConnection.class),
+        srcCrd.getKind(), ServiceRegistryConnection.class);
 
-    // lets create a client for the CRD
-    return client.customResources(akcCrdContext, CloudServiceAccountRequest.class,
-        CloudServiceAccountRequestList.class);
+        return client.resources(ServiceRegistryConnection.class, ServiceRegistryConnectionList.class);
   }
 
   private CustomResourceDefinition initCloudServiceAccountRequestCRDAndClient(

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/AbstractCloudServicesController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/AbstractCloudServicesController.java
@@ -12,8 +12,10 @@ import io.javaoperatorsdk.operator.api.UpdateControl;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 
 /** This class manages conditions and checks for updates on startup. */
@@ -22,6 +24,13 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
 
   public static final String COMPONENT_LABEL_KEY = "app.kubernetes.io/component";
   public static final String MANAGED_BY_LABEL_KEY = "app.kubernetes.io/managed-by";
+
+  public static final List<String> LEGACY_FINALIZERS = List.of(
+    "cloudservicesrequests.rhoas.redhat.com/finalizer",
+    "cloudserviceaccountrequests.rhoas.redhat.com/finalizer",
+    "kafkaconnections.rhoas.redhat.com/finalizer",
+    "serviceregistryconnections.rhoas.redhat.com/finalizer"
+  );
 
   public static final String COMPONENT_LABEL_VALUE = "external-service";
   public static final String MANAGED_BY_LABEL_VALUE = "rhoas";
@@ -46,6 +55,11 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
   /** This method is overriden by the proxies, but should not be overriden by you, the developer. */
   public UpdateControl<T> createOrUpdateResource(T resource, Context<T> context) {
     LOG.info("Updating resource " + resource.getCRDName());
+
+    if (shouldRemoveFinalizer(resource)) {
+      removeFinalizer(resource);
+      return UpdateControl.updateCustomResource(resource).withReSchedule(5, TimeUnit.SECONDS);
+    }
 
     if (shouldProcess(resource)) {
       var updateLabels = requiresLabelUpdate(resource);
@@ -94,6 +108,27 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
     }
     return updateRequired;
   }
+
+  /**
+   * We used to have finalizers for some classes, but these were removed.
+   * This method checks to see if a legacy finalizer is attatched and removes it.
+   * 
+   * @param resource
+   * @return if a finalizer should be removed
+   */
+  private boolean shouldRemoveFinalizer(T resource) {
+    var finalizers = resource.getMetadata().getFinalizers();
+    var toRemove = finalizers.stream().filter(finalizer -> LEGACY_FINALIZERS.contains(finalizer)).collect(Collectors.toList());
+    return toRemove.size() > 0;
+  }
+
+  private void removeFinalizer(T resource) {
+    var finalizers = resource.getMetadata().getFinalizers();
+    var toRemove = finalizers.stream().filter(finalizer -> LEGACY_FINALIZERS.contains(finalizer)).collect(Collectors.toList());
+    LOG.warning("Found legacy Finalizers " + toRemove);
+    toRemove.forEach(finalizer -> resource.removeFinalizer(finalizer));
+  }
+
 
   /**
    * checks if resource should process

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/AbstractCloudServicesController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/AbstractCloudServicesController.java
@@ -25,12 +25,11 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
   public static final String COMPONENT_LABEL_KEY = "app.kubernetes.io/component";
   public static final String MANAGED_BY_LABEL_KEY = "app.kubernetes.io/managed-by";
 
-  public static final List<String> LEGACY_FINALIZERS = List.of(
-    "cloudservicesrequests.rhoas.redhat.com/finalizer",
-    "cloudserviceaccountrequests.rhoas.redhat.com/finalizer",
-    "kafkaconnections.rhoas.redhat.com/finalizer",
-    "serviceregistryconnections.rhoas.redhat.com/finalizer"
-  );
+  public static final List<String> LEGACY_FINALIZERS =
+      List.of("cloudservicesrequests.rhoas.redhat.com/finalizer",
+          "cloudserviceaccountrequests.rhoas.redhat.com/finalizer",
+          "kafkaconnections.rhoas.redhat.com/finalizer",
+          "serviceregistryconnections.rhoas.redhat.com/finalizer");
 
   public static final String COMPONENT_LABEL_VALUE = "external-service";
   public static final String MANAGED_BY_LABEL_VALUE = "rhoas";
@@ -110,21 +109,23 @@ public abstract class AbstractCloudServicesController<T extends CustomResource>
   }
 
   /**
-   * We used to have finalizers for some classes, but these were removed.
-   * This method checks to see if a legacy finalizer is attatched and removes it.
+   * We used to have finalizers for some classes, but these were removed. This method checks to see
+   * if a legacy finalizer is attatched and removes it.
    * 
    * @param resource
    * @return if a finalizer should be removed
    */
   private boolean shouldRemoveFinalizer(T resource) {
     var finalizers = resource.getMetadata().getFinalizers();
-    var toRemove = finalizers.stream().filter(finalizer -> LEGACY_FINALIZERS.contains(finalizer)).collect(Collectors.toList());
+    var toRemove = finalizers.stream().filter(finalizer -> LEGACY_FINALIZERS.contains(finalizer))
+        .collect(Collectors.toList());
     return toRemove.size() > 0;
   }
 
   private void removeFinalizer(T resource) {
     var finalizers = resource.getMetadata().getFinalizers();
-    var toRemove = finalizers.stream().filter(finalizer -> LEGACY_FINALIZERS.contains(finalizer)).collect(Collectors.toList());
+    var toRemove = finalizers.stream().filter(finalizer -> LEGACY_FINALIZERS.contains(finalizer))
+        .collect(Collectors.toList());
     LOG.warning("Found legacy Finalizers " + toRemove);
     toRemove.forEach(finalizer -> resource.removeFinalizer(finalizer));
   }


### PR DESCRIPTION
When we removed finalizers from our controllers, we neglected to remove them from existing resources. This PR cleans up finalizers for resources. This happens in two places : first the abstract controller cleans up finalizers for resources which have not been deleted second: the operator startup removes finalizers from deleted resources. This is because controllers don't receive update events for deleted resources if the finalizers have been removed from the controller and therefor the controller can't handle that update.

# Testing Instructions
 0. Create your resources (KafkaConnection, ServiceRegistryConnection, CloudServicesRequest, CloudServiceAccountRequest) normally. They should not have finalizers if the operator is running.

 1. Add a finalizer for each of the these types. The finalizer should match the type and be from this list : https://github.com/redhat-developer/app-services-operator/pull/294/files#diff-fdef1da60a798f1a84ea9964e0dc966deb4bf93a584b04d36e9628fdb78a365cR28

 2. The operator should remove the finalizer automatically after you add it and log a warning in the console.
 3. Turn off the operator
 4. Repeat step 1
 5. delete the custom resource with a finalizer
 6. Restart the operator
 7. The deleted resource should have the finalizer removed and then be cleaned up
