### PR TITLE
Restore finalizers for deletion

### DIFF
--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
@@ -12,7 +12,7 @@ import javax.inject.Inject;
 import java.time.Instant;
 
 /** Controller for CloudServiceAccountRequest CRs */
-@Controller(finalizerName = Controller.NO_FINALIZER)
+@Controller
 public class CloudServiceAccountRequestController
     extends AbstractCloudServicesController<CloudServiceAccountRequest> {
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServicesRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServicesRequestController.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
-@Controller(finalizerName = Controller.NO_FINALIZER)
+@Controller
 public class CloudServicesRequestController
     extends AbstractCloudServicesController<CloudServicesRequest> {
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/KafkaConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/KafkaConnectionController.java
@@ -13,7 +13,7 @@ import javax.inject.Inject;
 import java.time.Instant;
 import java.util.logging.Logger;
 
-@Controller(finalizerName = Controller.NO_FINALIZER)
+@Controller
 public class KafkaConnectionController extends AbstractCloudServicesController<KafkaConnection> {
 
   private static final Logger LOG = Logger.getLogger(KafkaConnectionController.class.getName());

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
@@ -6,14 +6,11 @@ import com.openshift.cloud.utils.ConnectionResourcesMetadata;
 import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.ServiceRegistryConnection;
 import io.javaoperatorsdk.operator.api.Context;
-import io.javaoperatorsdk.operator.api.Controller;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.inject.Inject;
 import java.time.Instant;
 
-@Controller(finalizerName = Controller.NO_FINALIZER)
 public class ServiceRegistryConnectionController
     extends AbstractCloudServicesController<ServiceRegistryConnection> {
 


### PR DESCRIPTION
This PR restores creation of finalizer on resource creation (in case of existing finalizers operator should handle it)

## Verification

1. Run operator on this branch 
2. Create Kafka Resource
3. Review finalizers on the resource
3. Delete namespace
