### PR TITLE
fix: dynamic config for sso provider url

### DIFF
--- a/source/rhoas/pom.xml
+++ b/source/rhoas/pom.xml
@@ -30,12 +30,12 @@
     <dependency>
       <groupId>com.redhat.cloud</groupId>
       <artifactId>kafka-management-sdk</artifactId>
-      <version>0.15.1</version>
+      <version>0.20.3</version>
     </dependency>
     <dependency>
       <groupId>com.redhat.cloud</groupId>
       <artifactId>kafka-instance-sdk</artifactId>
-      <version>0.15.1</version>
+      <version>0.20.3</version>
     </dependency>
     <dependency>
       <groupId>com.redhat.cloud</groupId>

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
@@ -10,21 +10,17 @@ import com.openshift.cloud.api.kas.models.KafkaRequest;
 import com.openshift.cloud.api.kas.models.KafkaRequestList;
 import com.openshift.cloud.api.kas.models.ServiceAccount;
 import com.openshift.cloud.api.kas.models.ServiceAccountRequest;
+import com.openshift.cloud.api.kas.models.SsoProvider;
 import com.openshift.cloud.controllers.ConditionAwareException;
 import com.openshift.cloud.controllers.ConditionUtil;
 import com.openshift.cloud.v1alpha.models.CloudServiceAccountRequestSpec;
 import com.openshift.cloud.v1alpha.models.CloudServiceCondition;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 @ApplicationScoped
 public class KafkaApiClient {
-
-  @Inject
-  KubernetesClient k8sClient;
 
   @ConfigProperty(name = "rhoas.client.apiBasePath")
   String clientBasePath;
@@ -55,6 +51,16 @@ public class KafkaApiClient {
   public KafkaRequestList listKafkas(String accessToken) throws ConditionAwareException {
     try {
       return createClient(accessToken).getKafkas(null, null, null, null);
+    } catch (ApiException e) {
+      String message = ConditionUtil.getStandarizedErrorMessage(e.getCode(), e);
+      throw new ConditionAwareException(message, e, CloudServiceCondition.Type.UserKafkasUpToDate,
+          CloudServiceCondition.Status.False, e.getClass().getName(), message);
+    }
+  }
+
+  public SsoProvider getSSOProviders(String accessToken) throws ConditionAwareException {
+    try {
+      return createSecurityClient(accessToken).getSsoProviders();
     } catch (ApiException e) {
       String message = ConditionUtil.getStandarizedErrorMessage(e.getCode(), e);
       throw new ConditionAwareException(message, e, CloudServiceCondition.Type.UserKafkasUpToDate,

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
@@ -38,7 +38,7 @@ public class ServiceRegistryConnectionController
 
     String accessToken = accessTokenSecretTool.getAccessToken(accessTokenSecretName, namespace);
 
-    var provider= ssoApiClient.getSSOProviders(accessToken);
+    var provider = ssoApiClient.getSSOProviders(accessToken);
 
     var registry = apiClient.getServiceRegistryById(registryId, accessToken);
     var status = resource.getStatus();

--- a/source/rhoas/src/main/java/com/openshift/cloud/utils/ConnectionResourcesMetadata.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/utils/ConnectionResourcesMetadata.java
@@ -8,30 +8,30 @@ import java.util.Map;
  */
 public class ConnectionResourcesMetadata {
 
-    private static final String UI_REF_TEMPLATE =
-        "https://console.redhat.com/beta/application-services/streams/kafkas/%s";
+  private static final String UI_REF_TEMPLATE =
+      "https://console.redhat.com/beta/application-services/streams/kafkas/%s";
 
-    /**
-     * Contains hardcoded values for all metadata for Kafka specific properties
-     *
-     * @param kafkaId
-     * @return
-     */
-    public static Map<String, String> buildKafkaMetadata(String kafkaId) {
-        var map = new HashMap<String, String>();
-        map.put("saslMechanism", "PLAIN");
-        map.put("securityProtocol", "SASL_SSL");
-        map.put("cloudUI", String.format(UI_REF_TEMPLATE, kafkaId));
-        map.put("provider", "rhoas");
-        map.put("type", "kafka");
-        return map;
-    }
+  /**
+   * Contains hardcoded values for all metadata for Kafka specific properties
+   *
+   * @param kafkaId
+   * @return
+   */
+  public static Map<String, String> buildKafkaMetadata(String kafkaId) {
+    var map = new HashMap<String, String>();
+    map.put("saslMechanism", "PLAIN");
+    map.put("securityProtocol", "SASL_SSL");
+    map.put("cloudUI", String.format(UI_REF_TEMPLATE, kafkaId));
+    map.put("provider", "rhoas");
+    map.put("type", "kafka");
+    return map;
+  }
 
-    public static Map<String, String> buildServiceMetadata(String oauthToken) {
-        var map = new HashMap<String, String>();
-        map.put("provider", "rhoas");
-        map.put("oauthTokenUrl", oauthToken);
-        map.put("type", "serviceregistry");
-        return map;
-    }
+  public static Map<String, String> buildServiceMetadata(String oauthToken) {
+    var map = new HashMap<String, String>();
+    map.put("provider", "rhoas");
+    map.put("oauthTokenUrl", oauthToken);
+    map.put("type", "serviceregistry");
+    return map;
+  }
 }

--- a/source/rhoas/src/main/java/com/openshift/cloud/utils/ConnectionResourcesMetadata.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/utils/ConnectionResourcesMetadata.java
@@ -3,35 +3,35 @@ package com.openshift.cloud.utils;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Contains generic metadata for the resource connection instances */
+/**
+ * Contains generic metadata for the resource connection instances
+ */
 public class ConnectionResourcesMetadata {
 
-  private static final String UI_REF_TEMPLATE =
-      "https://console.redhat.com/beta/application-services/streams/kafkas/%s";
+    private static final String UI_REF_TEMPLATE =
+        "https://console.redhat.com/beta/application-services/streams/kafkas/%s";
 
-  private static final String SRS_OAUTH_TEMPLATE = "%s/realms/%s/protocol/openid-connect/token";
+    /**
+     * Contains hardcoded values for all metadata for Kafka specific properties
+     *
+     * @param kafkaId
+     * @return
+     */
+    public static Map<String, String> buildKafkaMetadata(String kafkaId) {
+        var map = new HashMap<String, String>();
+        map.put("saslMechanism", "PLAIN");
+        map.put("securityProtocol", "SASL_SSL");
+        map.put("cloudUI", String.format(UI_REF_TEMPLATE, kafkaId));
+        map.put("provider", "rhoas");
+        map.put("type", "kafka");
+        return map;
+    }
 
-  /**
-   * Contains hardcoded values for all metadata for Kafka specific properties
-   *
-   * @param kafkaId
-   * @return
-   */
-  public static Map<String, String> buildKafkaMetadata(String kafkaId) {
-    var map = new HashMap<String, String>();
-    map.put("saslMechanism", "PLAIN");
-    map.put("securityProtocol", "SASL_SSL");
-    map.put("cloudUI", String.format(UI_REF_TEMPLATE, kafkaId));
-    map.put("provider", "rhoas");
-    map.put("type", "kafka");
-    return map;
-  }
-
-  public static Map<String, String> buildServiceMetadata(String oauthHost, String oauthRealm) {
-    var map = new HashMap<String, String>();
-    map.put("provider", "rhoas");
-    map.put("oauthTokenUrl", String.format(SRS_OAUTH_TEMPLATE, oauthHost, oauthRealm));
-    map.put("type", "serviceregistry");
-    return map;
-  }
+    public static Map<String, String> buildServiceMetadata(String oauthToken) {
+        var map = new HashMap<String, String>();
+        map.put("provider", "rhoas");
+        map.put("oauthTokenUrl", oauthToken);
+        map.put("type", "serviceregistry");
+        return map;
+    }
 }

--- a/source/rhoas/src/main/resources/application.properties
+++ b/source/rhoas/src/main/resources/application.properties
@@ -15,9 +15,5 @@ quarkus.log.level=${RHOAS_LOG_LEVEL:INFO}
 rhoas.client.apiBasePath=${CLOUD_SERVICES_API:https://api.openshift.com}
 auth.serverUrl=${CLOUD_SERVICES_SSO:https://sso.redhat.com/auth/realms/redhat-external}
 
-rhoas.client.srsOAuthHost=${MAS_AUTH_URL:https://identity.api.openshift.com/auth}
-rhoas.client.srsOAuthRealm=${MAS_AUTH_REALM:rhoas}
-rhoas.client.srsOAuthTokenPath=${MAS_AUTH_URL_TOKEN_PATH:realms/rhoas/protocol/openid-connect/token}
-
 ## Enable clusters without valid certificated
 quarkus.kubernetes-client.trust-certs=true

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/ServiceRegistryConnectionControllerTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/ServiceRegistryConnectionControllerTest.java
@@ -64,12 +64,13 @@ public class ServiceRegistryConnectionControllerTest {
             .withName("kc-test").build())
         .withSpec(new ServiceRegistryConnectionSpecBuilder()
             .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
-            .withCredentials(new Credentials("sa-secret")).withServiceRegistryId("1234567890").build())
+            .withCredentials(new Credentials("sa-secret")).withServiceRegistryId("1234567890")
+            .build())
         .build();
     var result = controller.createOrUpdateResource(registryConnection,
         EmptyContext.emptyContext(ServiceRegistryConnection.class));
 
-    var labels =  result.getCustomResource().getMetadata().getLabels();
+    var labels = result.getCustomResource().getMetadata().getLabels();
 
     assertEquals(AbstractCloudServicesController.COMPONENT_LABEL_VALUE,
         labels.get(AbstractCloudServicesController.COMPONENT_LABEL_KEY));
@@ -85,7 +86,8 @@ public class ServiceRegistryConnectionControllerTest {
             .withName("kc-test").build())
         .withSpec(new ServiceRegistryConnectionSpecBuilder()
             .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
-            .withCredentials(new Credentials("sa-secret")).withServiceRegistryId("1234567890").build())
+            .withCredentials(new Credentials("sa-secret")).withServiceRegistryId("1234567890")
+            .build())
         .build();
 
     var result = controller.createOrUpdateResource(registryConnection,
@@ -106,6 +108,8 @@ public class ServiceRegistryConnectionControllerTest {
     var metaData = status.getMetadata();
     assertEquals("rhoas", metaData.get("provider"));
     assertEquals("serviceregistry", metaData.get("type"));
-    assertEquals("https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token", metaData.get("oauthTokenUrl"));
+    assertEquals(
+        "https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token",
+        metaData.get("oauthTokenUrl"));
   }
 }

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/ServiceRegistryConnectionControllerTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/ServiceRegistryConnectionControllerTest.java
@@ -1,0 +1,111 @@
+package com.openshift.cloud.test;
+
+import com.openshift.cloud.controllers.AbstractCloudServicesController;
+import com.openshift.cloud.controllers.ConditionUtil;
+import com.openshift.cloud.controllers.KafkaConnectionController;
+import com.openshift.cloud.controllers.ServiceRegistryConnectionController;
+import com.openshift.cloud.test.util.EmptyContext;
+import com.openshift.cloud.test.util.MockAccessTokenSecretToolProfile;
+import com.openshift.cloud.v1alpha.models.CloudServiceCondition;
+import com.openshift.cloud.v1alpha.models.CloudServiceCondition.Status;
+import com.openshift.cloud.v1alpha.models.CloudServiceCondition.Type;
+import com.openshift.cloud.v1alpha.models.Credentials;
+import com.openshift.cloud.v1alpha.models.KafkaConnection;
+import com.openshift.cloud.v1alpha.models.KafkaConnectionBuilder;
+import com.openshift.cloud.v1alpha.models.KafkaConnectionSpecBuilder;
+import com.openshift.cloud.v1alpha.models.ServiceRegistryConnection;
+import com.openshift.cloud.v1alpha.models.ServiceRegistryConnectionBuilder;
+import com.openshift.cloud.v1alpha.models.ServiceRegistryConnectionSpecBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.bf2.test.mock.QuarkusKubeMockServer;
+import org.bf2.test.mock.QuarkusKubernetesMockServer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.net.HttpURLConnection;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTestResource(QuarkusKubeMockServer.class)
+@TestProfile(MockAccessTokenSecretToolProfile.class)
+@QuarkusTest
+public class ServiceRegistryConnectionControllerTest {
+
+  @QuarkusKubernetesMockServer
+  KubernetesServer server;
+
+  @Inject
+  ServiceRegistryConnectionController controller;
+
+  /** Adds a secret to the k8s mock server */
+  @BeforeEach
+  public void setSecret() {
+    var secret = new SecretBuilder().withNewMetadata().withNamespace("test")
+        .withName("rh-managed-services-api-accesstoken").endMetadata()
+        .addToData(Map.of("value", "bXl0b2tlbg=="));
+
+    server.expect().get()
+        .withPath("/api/v1/namespaces/test/secrets/rh-managed-services-api-accesstoken")
+        .andReturn(HttpURLConnection.HTTP_OK, secret.build()).once();
+  }
+
+  @Test
+  public void testRegistryControllerEnforcesRequiredLabels() {
+    var registryConnection = new ServiceRegistryConnectionBuilder()
+        .withMetadata(new ObjectMetaBuilder().withGeneration(10l).withNamespace("test")
+            .withName("kc-test").build())
+        .withSpec(new ServiceRegistryConnectionSpecBuilder()
+            .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
+            .withCredentials(new Credentials("sa-secret")).withServiceRegistryId("1234567890").build())
+        .build();
+    var result = controller.createOrUpdateResource(registryConnection,
+        EmptyContext.emptyContext(ServiceRegistryConnection.class));
+
+    var labels =  result.getCustomResource().getMetadata().getLabels();
+
+    assertEquals(AbstractCloudServicesController.COMPONENT_LABEL_VALUE,
+        labels.get(AbstractCloudServicesController.COMPONENT_LABEL_KEY));
+    assertEquals(AbstractCloudServicesController.MANAGED_BY_LABEL_VALUE,
+        labels.get(AbstractCloudServicesController.MANAGED_BY_LABEL_KEY));
+
+  }
+
+  @Test
+  public void testKafkaConnectionRequest() {
+    var registryConnection = new ServiceRegistryConnectionBuilder()
+        .withMetadata(new ObjectMetaBuilder().withGeneration(10l).withNamespace("test")
+            .withName("kc-test").build())
+        .withSpec(new ServiceRegistryConnectionSpecBuilder()
+            .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
+            .withCredentials(new Credentials("sa-secret")).withServiceRegistryId("1234567890").build())
+        .build();
+
+    var result = controller.createOrUpdateResource(registryConnection,
+        EmptyContext.emptyContext(ServiceRegistryConnection.class));
+    Assertions.assertNotNull(result);
+    Assertions.assertNotNull(result.getCustomResource());
+    Assertions.assertNotNull(result.getCustomResource().getStatus());
+
+    var status = result.getCustomResource().getStatus();
+
+    CloudServiceCondition condition =
+        ConditionUtil.getCondition(status.getConditions(), Type.AcccesTokenSecretValid);
+    assertEquals(Status.True, condition.getStatus());
+
+    assertEquals("null/apis/registry/v2", status.getRegistryUrl());
+    assertEquals("sa-secret", status.getServiceAccountSecretName());
+
+    var metaData = status.getMetadata();
+    assertEquals("rhoas", metaData.get("provider"));
+    assertEquals("serviceregistry", metaData.get("type"));
+    assertEquals("https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token", metaData.get("oauthTokenUrl"));
+  }
+}


### PR DESCRIPTION
## Adding dynamic support for sso config

When backend changes sso configuration operator should dynamically change url to new config

## Progress

- [x] Dynamic config implementation 
- [x] Cleanup of the custom properties (including external CI overrides)
- [x] Unit tests
- [x] Verification on Kubernetes 
- [x] Reformat code :)
- [ ] Verification for the App guides (Summit apps)
- [ ] Verification on Sandbox beta

## Verfication

### Manually installing CRDS

For rapid testing of RHOAS CLI we can use Operator CRDs in headless mode (without running controller).

----
minikube start
cd olm/olm-catalog/rhoas-operator/0.9.0/manifests 
kubectl apply -f .
----

###  Testing with running operator

Operator can be started to process all requests created by RHOAS CLI

----
mvn quarkus:dev -Dkubernetes.trust.certificates=true
----

### Creation of resource

We should create new resource for service registry as follows:

```yaml
apiVersion: rhoas.redhat.com/v1alpha1
kind: ServiceRegistryConnection
metadata:
  name: test-connection
  namespace: rhoas-operator
spec:
  accessTokenSecretName: rh-managed-services-api-accesstoken
  serviceRegistryId: "valid-service-regsitry-id"
  credentials:
    serviceAccountSecretName: service-account-secret
```

## Problems with that approach

RHOAS Operator will not reconcile again resources that were processed due to performance optimalization. This means that while we are getting dynamic token url change it will be applied *only to the new or changed resources*. Users who created CR already will need to recreate their CR.

Additionally service binding doesn't listen to input resources which means that we should also recreate entire binding. While this will mount new volume in kubernetes most of the applications need to be restarted to pick up new file or env variables. 

![Screenshot 2022-05-27 at 11 48 48](https://user-images.githubusercontent.com/981838/170685660-f40036c2-2cff-4b52-a151-54c8be9e0d38.png)

This means that most of existing users will be impacted despite us having dynamic sso switch. Mitigation for this would be to migrate sandbox users (but for users clusters this will need to be mitigated manually - thru release notes.


