### PR TITLE
Update operator to work with reconcile loop instead of event based system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <java.version>11</java.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <quarkus.version>2.6.1.Final</quarkus.version>
+        <quarkus.version>2.9.2.Final</quarkus.version>
         <log4j2.version>2.17.1</log4j2.version>
 
     </properties>

--- a/rhoas-operator-parent.iml
+++ b/rhoas-operator-parent.iml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="CheckStyle-IDEA-Module">
+    <option name="configuration">
+      <map />
+    </option>
+  </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />

--- a/source/rhoas/pom.xml
+++ b/source/rhoas/pom.xml
@@ -13,8 +13,8 @@
   <name>rhoas-operator</name>
   <description>rhoas-operator</description>
   <properties>
-    <fabric8.version>5.10.1</fabric8.version>
-    <quarkus.operator.sdk.version>2.0.2</quarkus.operator.sdk.version>
+    <fabric8.version>5.12.2</fabric8.version>
+    <quarkus.operator.sdk.version>4.0.0.Beta2</quarkus.operator.sdk.version>
   </properties>
   <dependencies>
     <dependency>

--- a/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/RHOASOperator.java
@@ -58,16 +58,16 @@ public class RHOASOperator implements QuarkusApplication {
     LOG.info("Using API URL: " + clientBasePath);
 
     ControllerConfiguration<?> config = configuration.getConfigurationFor(connectionController);
-    LOG.info("CR class: " + config.getCustomResourceClass());
+    LOG.info("CR class: " + config.getResourceClass());
 
     config = configuration.getConfigurationFor(requestController);
-    LOG.info("CR class: " + config.getCustomResourceClass());
+    LOG.info("CR class: " + config.getResourceClass());
 
     config = configuration.getConfigurationFor(serviceAccountRequestController);
-    LOG.info("CR class: " + config.getCustomResourceClass());
+    LOG.info("CR class: " + config.getResourceClass());
 
     config = configuration.getConfigurationFor(serviceRegistryConnectionController);
-    LOG.info("CR class: " + config.getCustomResourceClass());
+    LOG.info("CR class: " + config.getResourceClass());
 
     operator.start();
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServiceAccountRequestController.java
@@ -5,14 +5,14 @@ import com.openshift.cloud.beans.KafkaApiClient;
 import com.openshift.cloud.beans.ServiceAccountUtil;
 import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.CloudServiceAccountRequest;
-import io.javaoperatorsdk.operator.api.Context;
-import io.javaoperatorsdk.operator.api.Controller;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 
 import javax.inject.Inject;
 import java.time.Instant;
 
 /** Controller for CloudServiceAccountRequest CRs */
-@Controller
+@ControllerConfiguration
 public class CloudServiceAccountRequestController
     extends AbstractCloudServicesController<CloudServiceAccountRequest> {
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServicesRequestController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/CloudServicesRequestController.java
@@ -7,15 +7,15 @@ import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.CloudServicesRequest;
 import com.openshift.cloud.v1alpha.models.ServiceRegistry;
 import com.openshift.cloud.v1alpha.models.UserKafka;
-import io.javaoperatorsdk.operator.api.Context;
-import io.javaoperatorsdk.operator.api.Controller;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 
-@Controller
+@ControllerConfiguration
 public class CloudServicesRequestController
     extends AbstractCloudServicesController<CloudServicesRequest> {
 
@@ -32,14 +32,6 @@ public class CloudServicesRequestController
   ServiceRegistryApiClient srsApiClient;
 
   public CloudServicesRequestController() {}
-
-  /**
-   * @return true if there were changes, false otherwise
-   **/
-  @Override
-  public void init(EventSourceManager eventSourceManager) {
-    LOG.info("Init! This is where we would add watches for child resources");
-  }
 
   @Override
   void doCreateOrUpdateResource(CloudServicesRequest resource,

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/KafkaConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/KafkaConnectionController.java
@@ -6,14 +6,14 @@ import com.openshift.cloud.beans.ServiceAccountUtil;
 import com.openshift.cloud.utils.ConnectionResourcesMetadata;
 import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.KafkaConnection;
-import io.javaoperatorsdk.operator.api.Context;
-import io.javaoperatorsdk.operator.api.Controller;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 
 import javax.inject.Inject;
 import java.time.Instant;
 import java.util.logging.Logger;
 
-@Controller
+@ControllerConfiguration
 public class KafkaConnectionController extends AbstractCloudServicesController<KafkaConnection> {
 
   private static final Logger LOG = Logger.getLogger(KafkaConnectionController.class.getName());
@@ -23,9 +23,6 @@ public class KafkaConnectionController extends AbstractCloudServicesController<K
 
   @Inject
   AccessTokenSecretTool accessTokenSecretTool;
-
-  @Inject
-  ServiceAccountUtil serviceAccountUtil;
 
   @Override
   void doCreateOrUpdateResource(KafkaConnection resource, Context<KafkaConnection> context)

--- a/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/controllers/ServiceRegistryConnectionController.java
@@ -6,7 +6,7 @@ import com.openshift.cloud.beans.ServiceRegistryApiClient;
 import com.openshift.cloud.utils.ConnectionResourcesMetadata;
 import com.openshift.cloud.utils.InvalidUserInputException;
 import com.openshift.cloud.v1alpha.models.ServiceRegistryConnection;
-import io.javaoperatorsdk.operator.api.Context;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.inject.Inject;

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/CloudServiceAccountRequestTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/CloudServiceAccountRequestTest.java
@@ -56,9 +56,9 @@ public class CloudServiceAccountRequestTest {
             .build())
         .build();
 
-    var result = controller.createOrUpdateResource(csar,
+    var result = controller.reconcile(csar,
         EmptyContext.emptyContext(CloudServiceAccountRequest.class));
 
-    Assertions.assertTrue(result.isUpdateStatusSubResource());
+    Assertions.assertTrue(result.isUpdateStatus());
   }
 }

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/CloudServicesRequestControllerTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/CloudServicesRequestControllerTest.java
@@ -70,21 +70,21 @@ public class CloudServicesRequestControllerTest {
             .withName("csr-test").build())
         .withSpec(new CloudServicesRequestSpec("rh-managed-services-api-accesstoken")).build();
 
-    var result = controller.createOrUpdateResource(cloudServicesRequest,
+    var result = controller.reconcile(cloudServicesRequest,
         EmptyContext.emptyContext(CloudServicesRequest.class));
 
     Assertions.assertNotNull(result);
-    Assertions.assertNotNull(result.getCustomResource());
-    Assertions.assertNotNull(result.getCustomResource().getStatus());
+    Assertions.assertNotNull(result.getResource());
+    Assertions.assertNotNull(result.getResource().getStatus());
 
     CloudServicesRequestStatus status =
-        (CloudServicesRequestStatus) result.getCustomResource().getStatus();
+        (CloudServicesRequestStatus) result.getResource().getStatus();
 
     var condition = ConditionUtil.getCondition(status.getConditions(), Type.AcccesTokenSecretValid);
     assertEquals(Status.True, condition.getStatus());
 
     List<UserKafka> userKafkas =
-        ((CloudServicesRequest) result.getCustomResource()).getStatus().getUserKafkas();
+        ((CloudServicesRequest) result.getResource()).getStatus().getUserKafkas();
     Assertions.assertNotNull(userKafkas);
     Assertions.assertEquals("1234567890", userKafkas.get(0).getId());
   }
@@ -102,20 +102,20 @@ public class CloudServicesRequestControllerTest {
             .withName("csr-test").build())
         .withSpec(new CloudServicesRequestSpec("rh-managed-services-api-accesstoken")).build();
 
-    var result = controller.createOrUpdateResource(cloudServicesRequest,
+    var result = controller.reconcile(cloudServicesRequest,
         EmptyContext.emptyContext(CloudServicesRequest.class));
 
-    UserKafka userKafkas = (result.getCustomResource()).getStatus().getUserKafkas().get(0);
+    UserKafka userKafkas = (result.getResource()).getStatus().getUserKafkas().get(0);
 
     // change the default kafka status from "status" to "ready"
     changeDefaultKafkaInMock();
 
     cloudServicesRequest.getMetadata().setGeneration(11l);
 
-    result = controller.createOrUpdateResource(cloudServicesRequest,
+    result = controller.reconcile(cloudServicesRequest,
         EmptyContext.emptyContext(CloudServicesRequest.class));
 
-    UserKafka userKafkas2 = (result.getCustomResource()).getStatus().getUserKafkas().get(0);
+    UserKafka userKafkas2 = (result.getResource()).getStatus().getUserKafkas().get(0);
     assertEquals("status", userKafkas.getStatus());
     assertEquals("ready", userKafkas2.getStatus());
   }

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/KafkaConnectionControllerTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/KafkaConnectionControllerTest.java
@@ -62,10 +62,10 @@ public class KafkaConnectionControllerTest {
             .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
             .withCredentials(new Credentials("sa-secret")).withKafkaId("1234567890").build())
         .build();
-    var result = controller.createOrUpdateResource(kafkaConnectionRequest,
+    var result = controller.reconcile(kafkaConnectionRequest,
         EmptyContext.emptyContext(KafkaConnection.class));
 
-    var labels = ((KafkaConnection) result.getCustomResource()).getMetadata().getLabels();
+    var labels = ((KafkaConnection) result.getResource()).getMetadata().getLabels();
 
     assertEquals(AbstractCloudServicesController.COMPONENT_LABEL_VALUE,
         labels.get(AbstractCloudServicesController.COMPONENT_LABEL_KEY));
@@ -88,14 +88,14 @@ public class KafkaConnectionControllerTest {
             .withAccessTokenSecretName("rh-managed-services-api-accesstoken")
             .withCredentials(new Credentials("sa-secret")).withKafkaId("1234567890").build())
         .build();
-    var result = controller.createOrUpdateResource(kafkaConnectionRequest,
+    var result = controller.reconcile(kafkaConnectionRequest,
         EmptyContext.emptyContext(KafkaConnection.class));
 
     Assertions.assertNotNull(result);
-    Assertions.assertNotNull(result.getCustomResource());
-    Assertions.assertNotNull(result.getCustomResource().getStatus());
+    Assertions.assertNotNull(result.getResource());
+    Assertions.assertNotNull(result.getResource().getStatus());
 
-    var status = ((KafkaConnection) result.getCustomResource()).getStatus();
+    var status = ((KafkaConnection) result.getResource()).getStatus();
 
     CloudServiceCondition condition =
         ConditionUtil.getCondition(status.getConditions(), Type.AcccesTokenSecretValid);

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/ServiceRegistryConnectionControllerTest.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/ServiceRegistryConnectionControllerTest.java
@@ -67,10 +67,10 @@ public class ServiceRegistryConnectionControllerTest {
             .withCredentials(new Credentials("sa-secret")).withServiceRegistryId("1234567890")
             .build())
         .build();
-    var result = controller.createOrUpdateResource(registryConnection,
+    var result = controller.reconcile(registryConnection,
         EmptyContext.emptyContext(ServiceRegistryConnection.class));
 
-    var labels = result.getCustomResource().getMetadata().getLabels();
+    var labels = result.getResource().getMetadata().getLabels();
 
     assertEquals(AbstractCloudServicesController.COMPONENT_LABEL_VALUE,
         labels.get(AbstractCloudServicesController.COMPONENT_LABEL_KEY));
@@ -90,13 +90,13 @@ public class ServiceRegistryConnectionControllerTest {
             .build())
         .build();
 
-    var result = controller.createOrUpdateResource(registryConnection,
+    var result = controller.reconcile(registryConnection,
         EmptyContext.emptyContext(ServiceRegistryConnection.class));
     Assertions.assertNotNull(result);
-    Assertions.assertNotNull(result.getCustomResource());
-    Assertions.assertNotNull(result.getCustomResource().getStatus());
+    Assertions.assertNotNull(result.getResource());
+    Assertions.assertNotNull(result.getResource().getStatus());
 
-    var status = result.getCustomResource().getStatus();
+    var status = result.getResource().getStatus();
 
     CloudServiceCondition condition =
         ConditionUtil.getCondition(status.getConditions(), Type.AcccesTokenSecretValid);

--- a/source/rhoas/src/test/java/com/openshift/cloud/test/util/EmptyContext.java
+++ b/source/rhoas/src/test/java/com/openshift/cloud/test/util/EmptyContext.java
@@ -1,24 +1,45 @@
 package com.openshift.cloud.test.util;
 
 import io.fabric8.kubernetes.client.CustomResource;
-import io.javaoperatorsdk.operator.api.Context;
-import io.javaoperatorsdk.operator.api.RetryInfo;
-import io.javaoperatorsdk.operator.processing.event.EventList;
-import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedDependentResourceContext;
+
 import java.util.Optional;
+import java.util.Set;
 
 public class EmptyContext {
   public static <T extends CustomResource> Context<T> emptyContext(Class<T> clazz) {
     return new Context<T>() {
+      @Override
+      public Optional<RetryInfo> getRetryInfo() {
+        return Optional.empty();
+      }
 
       @Override
-      public EventList getEvents() {
+      public <T1> Optional<T1> getSecondaryResource(Class<T1> expectedType) {
+        return Context.super.getSecondaryResource(expectedType);
+      }
+
+      @Override
+      public <T1> Set<T1> getSecondaryResources(Class<T1> aClass) {
         return null;
       }
 
       @Override
-      public Optional<RetryInfo> getRetryInfo() {
+      public <T1> Optional<T1> getSecondaryResource(Class<T1> aClass, String s) {
         return Optional.empty();
+      }
+
+      @Override
+      public ControllerConfiguration<T> getControllerConfiguration() {
+        return null;
+      }
+
+      @Override
+      public ManagedDependentResourceContext managedDependentResourceContext() {
+        return null;
       }
     };
   }


### PR DESCRIPTION
## Motivation

This PR updates Operator to the latest Operator SDK. However that version of operator changes completly how operator works. Operator is no longer listening to events - instead it does constant reconcile loop. This might have number of implications:

- Rate limiting
- IP whitelisting
- User blocking his own service account

We need to make sure that this changes are well tested across different environments and setups.

## User impact

Users will see their resources updating (specifically list of the services) automatically without changing CR. 
Number of implementations and workarounds in OpenShift console plugin will not be needed.
We need to change reconciler time and act only when resources require changes.