### PR TITLE
fix: use rhoas tools image

### DIFF
--- a/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
+++ b/olm/quickstarts/rhosak-openshift-connect-quickstart.yaml
@@ -117,7 +117,7 @@ spec:
             ii. On the **Add** page, click **Container images**.
                 The **Deploy Image** page opens.
 
-            iii. For the **Image name from external registry** option, enter `quay.io/rhosak/rhoas-tools`.
+            iii. For the **Image name from external registry** option, enter `quay.io/rhoas/tools`.
 
             iv. For the **Runtime icon** option, select `openshift`.
 


### PR DESCRIPTION
## Verification

No verification needed. We have ported the same image to the different repository:
https://quay.io/repository/rhoas/tools?tab=tags and we should use this one as older one is no longer kept up todate.