### PR TITLE
fix: use service accounts API

### DIFF
--- a/source/rhoas/pom.xml
+++ b/source/rhoas/pom.xml
@@ -34,6 +34,11 @@
     </dependency>
     <dependency>
       <groupId>com.redhat.cloud</groupId>
+      <artifactId>service-accounts-sdk</artifactId>
+      <version>0.27.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.redhat.cloud</groupId>
       <artifactId>kafka-instance-sdk</artifactId>
       <version>0.15.1</version>
     </dependency>

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
@@ -1,15 +1,15 @@
 package com.openshift.cloud.beans;
 
 import com.openshift.cloud.api.kas.DefaultApi;
-import com.openshift.cloud.api.kas.SecurityApi;
 import com.openshift.cloud.api.kas.invoker.ApiClient;
 import com.openshift.cloud.api.kas.invoker.ApiException;
 import com.openshift.cloud.api.kas.invoker.Configuration;
 import com.openshift.cloud.api.kas.invoker.auth.HttpBearerAuth;
 import com.openshift.cloud.api.kas.models.KafkaRequest;
 import com.openshift.cloud.api.kas.models.KafkaRequestList;
-import com.openshift.cloud.api.kas.models.ServiceAccount;
-import com.openshift.cloud.api.kas.models.ServiceAccountRequest;
+import com.openshift.cloud.api.serviceaccounts.ServiceAccountsApi;
+import com.openshift.cloud.api.serviceaccounts.models.ServiceAccountCreateRequestData;
+import com.openshift.cloud.api.serviceaccounts.models.ServiceAccountData;
 import com.openshift.cloud.controllers.ConditionAwareException;
 import com.openshift.cloud.controllers.ConditionUtil;
 import com.openshift.cloud.v1alpha.models.CloudServiceAccountRequestSpec;
@@ -29,8 +29,11 @@ public class KafkaApiClient {
   @ConfigProperty(name = "rhoas.client.apiBasePath")
   String clientBasePath;
 
-  private DefaultApi createClient(String bearerToken) {
+  @ConfigProperty(name = "auth.serverUrl")
+  String saAPIURL;
 
+
+  private DefaultApi createClient(String bearerToken) {
     ApiClient defaultClient = Configuration.getDefaultApiClient();
     defaultClient.setBasePath(clientBasePath);
 
@@ -62,14 +65,14 @@ public class KafkaApiClient {
     }
   }
 
-  public ServiceAccount createServiceAccount(CloudServiceAccountRequestSpec spec,
-      String accessToken) throws ConditionAwareException {
+  public ServiceAccountData createServiceAccount(CloudServiceAccountRequestSpec spec,
+                                                 String accessToken) throws ConditionAwareException {
     try {
-      var serviceAccountRequest = new ServiceAccountRequest();
+      var serviceAccountRequest = new ServiceAccountCreateRequestData();
       serviceAccountRequest.setDescription(spec.getServiceAccountDescription());
       serviceAccountRequest.setName(spec.getServiceAccountName());
       return createSecurityClient(accessToken).createServiceAccount(serviceAccountRequest);
-    } catch (ApiException e) {
+    } catch (com.openshift.cloud.api.serviceaccounts.invoker.ApiException e) {
       String message = ConditionUtil.getStandarizedErrorMessage(e.getCode(), e);
       throw new ConditionAwareException(message, e,
           CloudServiceCondition.Type.ServiceAccountCreated, CloudServiceCondition.Status.False,
@@ -77,17 +80,15 @@ public class KafkaApiClient {
     }
   }
 
-  // TODO create ACLs
-
-  private SecurityApi createSecurityClient(String bearerToken) {
-    ApiClient defaultClient = Configuration.getDefaultApiClient();
-    defaultClient.setBasePath(clientBasePath);
+  private ServiceAccountsApi createSecurityClient(String bearerToken) {
+    var defaultClient = new com.openshift.cloud.api.serviceaccounts.invoker.ApiClient();
+    defaultClient.setBasePath(saAPIURL);
 
     // Configure HTTP bearer authorization: Bearer
     HttpBearerAuth Bearer = (HttpBearerAuth) defaultClient.getAuthentication("Bearer");
     Bearer.setBearerToken(bearerToken);
 
-    return new SecurityApi(defaultClient);
+    return new ServiceAccountsApi(defaultClient);
   }
 }
 

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/KafkaApiClient.java
@@ -66,7 +66,7 @@ public class KafkaApiClient {
   }
 
   public ServiceAccountData createServiceAccount(CloudServiceAccountRequestSpec spec,
-                                                 String accessToken) throws ConditionAwareException {
+      String accessToken) throws ConditionAwareException {
     try {
       var serviceAccountRequest = new ServiceAccountCreateRequestData();
       serviceAccountRequest.setDescription(spec.getServiceAccountDescription());

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/MockKafkaApiClient.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/MockKafkaApiClient.java
@@ -43,7 +43,7 @@ public class MockKafkaApiClient extends KafkaApiClient {
 
   @Override
   public ServiceAccountData createServiceAccount(CloudServiceAccountRequestSpec spec,
-                                                 String accessToken) throws ConditionAwareException {
+      String accessToken) throws ConditionAwareException {
     var sa = new com.openshift.cloud.api.serviceaccounts.models.ServiceAccountData();
     sa.setClientId("clientID");
     sa.setSecret("clientSecret");

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/MockKafkaApiClient.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/MockKafkaApiClient.java
@@ -2,9 +2,8 @@ package com.openshift.cloud.beans;
 
 import com.openshift.cloud.api.kas.models.KafkaRequest;
 import com.openshift.cloud.api.kas.models.KafkaRequestList;
-import com.openshift.cloud.api.kas.models.ServiceAccount;
+import com.openshift.cloud.api.serviceaccounts.models.ServiceAccountData;
 import com.openshift.cloud.controllers.ConditionAwareException;
-import com.openshift.cloud.v1alpha.models.CloudServiceAccountRequest;
 import com.openshift.cloud.v1alpha.models.CloudServiceAccountRequestSpec;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -43,11 +42,11 @@ public class MockKafkaApiClient extends KafkaApiClient {
   }
 
   @Override
-  public ServiceAccount createServiceAccount(CloudServiceAccountRequestSpec spec,
-      String accessToken) throws ConditionAwareException {
-    ServiceAccount sa = new ServiceAccount();
+  public ServiceAccountData createServiceAccount(CloudServiceAccountRequestSpec spec,
+                                                 String accessToken) throws ConditionAwareException {
+    var sa = new com.openshift.cloud.api.serviceaccounts.models.ServiceAccountData();
     sa.setClientId("clientID");
-    sa.setClientSecret("clientSecret");
+    sa.setSecret("clientSecret");
     sa.setDescription(spec.getServiceAccountDescription());
     sa.setId("123456789");
     sa.setName(spec.getServiceAccountName());

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/ServiceAccountUtil.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/ServiceAccountUtil.java
@@ -1,6 +1,7 @@
 package com.openshift.cloud.beans;
 
 import com.openshift.cloud.api.kas.models.ServiceAccount;
+import com.openshift.cloud.api.serviceaccounts.models.ServiceAccountData;
 import com.openshift.cloud.controllers.ConditionAwareException;
 import com.openshift.cloud.v1alpha.models.CloudServiceAccountRequest;
 import com.openshift.cloud.v1alpha.models.CloudServiceCondition;
@@ -28,7 +29,7 @@ public class ServiceAccountUtil {
   KubernetesClient k8sClient;
 
   public void createSecretForServiceAccount(CloudServiceAccountRequest resource,
-      ServiceAccount serviceAccount) throws ConditionAwareException {
+      ServiceAccountData serviceAccount) throws ConditionAwareException {
     try {
       var secret = new SecretBuilder().editOrNewMetadata()
           .withName(resource.getSpec().getServiceAccountSecretName())
@@ -40,7 +41,7 @@ public class ServiceAccountUtil {
           .endMetadata()
           .withData(Map.of(TOKEN_CLIENT_SECRET_KEY,
               Base64.getEncoder().encodeToString(
-                  serviceAccount.getClientSecret().getBytes(Charset.defaultCharset())),
+                  serviceAccount.getSecret().getBytes(Charset.defaultCharset())),
               TOKEN_CLIENT_ID_KEY,
               Base64.getEncoder()
                   .encodeToString(serviceAccount.getClientId().getBytes(Charset.defaultCharset()))))

--- a/source/rhoas/src/main/java/com/openshift/cloud/beans/ServiceAccountUtil.java
+++ b/source/rhoas/src/main/java/com/openshift/cloud/beans/ServiceAccountUtil.java
@@ -40,8 +40,8 @@ public class ServiceAccountUtil {
               .withUid(resource.getMetadata().getUid()).build()))
           .endMetadata()
           .withData(Map.of(TOKEN_CLIENT_SECRET_KEY,
-              Base64.getEncoder().encodeToString(
-                  serviceAccount.getSecret().getBytes(Charset.defaultCharset())),
+              Base64.getEncoder()
+                  .encodeToString(serviceAccount.getSecret().getBytes(Charset.defaultCharset())),
               TOKEN_CLIENT_ID_KEY,
               Base64.getEncoder()
                   .encodeToString(serviceAccount.getClientId().getBytes(Charset.defaultCharset()))))


### PR DESCRIPTION
## Motivation

Update Operator to use Kas-fleet-manager API.
I have decided to Keep oudated kafka SDK as it introduces breaking changes/will require CR updates. This change only adds latest service accounts API