### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -16,13 +16,13 @@ jobs:
     
       - 
         name: Install git-chglog
-        uses: craicoverflow/install-git-chglog@v1
+        uses: craicoverflow/install-git-chglog@6d338c1d96dcbf12a2115fbe8e5b9817293aae33 #v1
 
       -
         name: Generate a CHANGELOG
         run: git-chglog -o CHANGELOG.md
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a #v4
         with:
           branch: main
           file_pattern: CHANGELOG.md

--- a/.github/workflows/enforce_conventional_commit.yml
+++ b/.github/workflows/enforce_conventional_commit.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v2
+      - uses: wagoid/commitlint-github-action@4b1bcb1c72f99fbd6aa6b34cc3fb59200f01f993 #v2

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -7,7 +7,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v2.4
+    - uses: github/issue-labeler@829a8bf1b184f74cc575b5435093a92c7b846983 #v2.4
       with:
         repo-token: "${{ secrets.PROJECT_MANAGER_TOKEN }}"
         configuration-path: .github/labeler.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       id: version-number
       run: echo "::set-output name=version::$(cat olm/version)"
     - name: Commit updated version
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@0fafdd62b84042d49ec0cb92d9cac7f7ce4ec79e #master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}            
     - name: Login to Quay.io

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
       
     - name: asciidoctor-ghpages
-      uses: manoelcampos/asciidoctor-ghpages-action@v2
+      uses: manoelcampos/asciidoctor-ghpages-action@9527ff583929b1000c23c209123bba4e98a21f08 #v2
       with:
         asciidoctor_params: --attribute=nofooter
         pdf_build: false


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
